### PR TITLE
feat(cli): ask for directories from user before creating new specification

### DIFF
--- a/api/handler/v1/runtime.go
+++ b/api/handler/v1/runtime.go
@@ -32,10 +32,6 @@ type NamespaceRepoFactory interface {
 	New(spec models.ProjectSpec) store.NamespaceRepository
 }
 
-type JobRepoFactory interface {
-	New(spec models.ProjectSpec) store.JobSpecRepository
-}
-
 type SecretRepoFactory interface {
 	New(spec models.ProjectSpec) store.ProjectSecretRepository
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,7 +15,6 @@ import (
 	v1handler "github.com/odpf/optimus/api/handler/v1"
 	pb "github.com/odpf/optimus/api/proto/odpf/optimus"
 	"github.com/odpf/optimus/models"
-	"github.com/odpf/optimus/store"
 	"github.com/pkg/errors"
 	cli "github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -26,7 +25,7 @@ var (
 )
 
 // deployCommand pushes current repo to optimus service
-func deployCommand(l logger, jobSpecRepo store.JobSpecRepository, conf config.Provider,
+func deployCommand(l logger, conf config.Provider, jobSpecRepo JobSpecRepository,
 	datastoreRepo models.DatastoreRepo, datastoreSpecFs map[string]afero.Fs) *cli.Command {
 	var projectName string
 	var namespace string
@@ -65,7 +64,7 @@ func deployCommand(l logger, jobSpecRepo store.JobSpecRepository, conf config.Pr
 }
 
 // postDeploymentRequest send a deployment request to service
-func postDeploymentRequest(l logger, projectName string, namespace string, jobSpecRepo store.JobSpecRepository,
+func postDeploymentRequest(l logger, projectName string, namespace string, jobSpecRepo JobSpecRepository,
 	conf config.Provider, datastoreRepo models.DatastoreRepo, datastoreSpecFs map[string]afero.Fs,
 	ignoreJobDeployment, ignoreResources bool) (err error) {
 	dialTimeoutCtx, dialCancel := context.WithTimeout(context.Background(), OptimusDialTimeout)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/odpf/optimus/utils"
 
-	"github.com/odpf/optimus/store"
-
 	pb "github.com/odpf/optimus/api/proto/odpf/optimus"
 	"github.com/pkg/errors"
 	cli "github.com/spf13/cobra"
@@ -24,7 +22,7 @@ var (
 	templateEngine = instance.NewGoEngine()
 )
 
-func renderCommand(l logger, host string, jobSpecRepo store.JobSpecRepository) *cli.Command {
+func renderCommand(l logger, host string, jobSpecRepo JobSpecRepository) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "render",
 		Short: "convert raw representation of specification to consumables",
@@ -36,7 +34,7 @@ func renderCommand(l logger, host string, jobSpecRepo store.JobSpecRepository) *
 	return cmd
 }
 
-func renderTemplateCommand(l logger, jobSpecRepo store.JobSpecRepository) *cli.Command {
+func renderTemplateCommand(l logger, jobSpecRepo JobSpecRepository) *cli.Command {
 	cmd := &cli.Command{
 		Use:     "template",
 		Short:   "render templates for a job to current 'render' directory",

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -57,7 +57,7 @@ var (
 
 	shutdownWait = 30 * time.Second
 
-	GRPCMaxRecvMsgSize = 25 << 20 // 25MB
+	GRPCMaxRecvMsgSize = 45 << 20 // 45MB
 )
 
 // projectJobSpecRepoFactory stores raw specifications
@@ -66,7 +66,7 @@ type projectJobSpecRepoFactory struct {
 }
 
 func (fac *projectJobSpecRepoFactory) New(project models.ProjectSpec) store.ProjectJobSpecRepository {
-	return postgres.NewProjectJobRepository(fac.db, project, postgres.NewAdapter(models.TaskRegistry, models.HookRegistry))
+	return postgres.NewProjectJobSpecRepository(fac.db, project, postgres.NewAdapter(models.TaskRegistry, models.HookRegistry))
 }
 
 // jobSpecRepoFactory stores raw specifications
@@ -75,8 +75,8 @@ type jobSpecRepoFactory struct {
 	projectJobSpecRepoFac projectJobSpecRepoFactory
 }
 
-func (fac *jobSpecRepoFactory) New(namespace models.NamespaceSpec) store.JobSpecRepository {
-	return postgres.NewJobRepository(
+func (fac *jobSpecRepoFactory) New(namespace models.NamespaceSpec) job.SpecRepository {
+	return postgres.NewJobSpecRepository(
 		fac.db,
 		namespace,
 		fac.projectJobSpecRepoFac.New(namespace.ProjectSpec),

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/odpf/optimus/models"
 
-	"github.com/odpf/optimus/store"
-
 	pb "github.com/odpf/optimus/api/proto/odpf/optimus"
 	"github.com/pkg/errors"
 	cli "github.com/spf13/cobra"
@@ -22,7 +20,7 @@ const (
 	validateTimeout = time.Minute * 3
 )
 
-func validateCommand(l logger, host string, jobSpecRepo store.JobSpecRepository) *cli.Command {
+func validateCommand(l logger, host string, jobSpecRepo JobSpecRepository) *cli.Command {
 	cmd := &cli.Command{
 		Use:   "validate",
 		Short: "check if specifications are valid for deployment",
@@ -33,7 +31,7 @@ func validateCommand(l logger, host string, jobSpecRepo store.JobSpecRepository)
 	return cmd
 }
 
-func validateJobCommand(l logger, host string, jobSpecRepo store.JobSpecRepository) *cli.Command {
+func validateJobCommand(l logger, host string, jobSpecRepo JobSpecRepository) *cli.Command {
 	var projectName string
 	var namespace string
 	cmd := &cli.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,13 +18,14 @@ const (
 )
 
 func versionCommand(l logger, host string) *cli.Command {
+	var serverVersion bool
 	c := &cli.Command{
 		Use:   "version",
 		Short: "Print the client version information",
 		RunE: func(c *cli.Command, args []string) error {
 			l.Printf(fmt.Sprintf("client: %s-%s", coloredNotice(config.Version), config.BuildCommit))
 
-			if host != "" {
+			if host != "" && serverVersion {
 				srvVer, err := getVersionRequest(config.Version, host)
 				if err != nil {
 					return err
@@ -34,6 +35,7 @@ func versionCommand(l logger, host string) *cli.Command {
 			return nil
 		},
 	}
+	c.Flags().BoolVar(&serverVersion, "with-server", false, "check for server version")
 	return c
 }
 

--- a/ext/datastore/bigquery/table_spec.go
+++ b/ext/datastore/bigquery/table_spec.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	validProjectName = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
-	validDatasetName = regexp.MustCompile(`^[\w]{3,1000}`) // golang's regex engine only let's you restrict maximum repeatitions to 1000 ¯\_(ツ)_/¯
+	validDatasetName = regexp.MustCompile(`^[\w]{3,1000}`) // golang's regex engine only let's you restrict maximum repetitions to 1000 ¯\_(ツ)_/¯
 	validTableName   = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	github.com/AlecAivazis/survey/v2 v2.2.7
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/emirpasic/gods v1.12.0
 	github.com/fatih/color v1.7.0
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0 h1:90Ly+6UfUypEF6vvvW5rQIv9opIL8CbmW9FT20LDQoY=
+github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0/go.mod h1:V+Qd57rJe8gd4eiGzZyg4h54VLHmYVVw54iMnlAMrF8=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=

--- a/job/job.go
+++ b/job/job.go
@@ -1,0 +1,11 @@
+package job
+
+import "github.com/odpf/optimus/models"
+
+// SpecRepository represents a storage interface for Job specifications at a namespace level
+type SpecRepository interface {
+	Save(models.JobSpec) error
+	GetByName(string) (models.JobSpec, error)
+	GetAll() ([]models.JobSpec, error)
+	Delete(string) error
+}

--- a/job/service.go
+++ b/job/service.go
@@ -32,9 +32,9 @@ type DependencyResolver interface {
 		jobSpec models.JobSpec, observer progress.Observer) (models.JobSpec, error)
 }
 
-// JobSpecRepoFactory is used to manage job specs at namespace level
-type JobSpecRepoFactory interface {
-	New(spec models.NamespaceSpec) store.JobSpecRepository
+// SpecRepoFactory is used to manage job specs at namespace level
+type SpecRepoFactory interface {
+	New(spec models.NamespaceSpec) SpecRepository
 }
 
 // ProjectJobSpecRepoFactory is used to manage job specs at project level
@@ -56,7 +56,7 @@ type JobRepoFactory interface {
 // and other properties. Finally, it syncs the jobs with corresponding
 // store
 type Service struct {
-	jobSpecRepoFactory        JobSpecRepoFactory
+	jobSpecRepoFactory        SpecRepoFactory
 	compiler                  models.JobCompiler
 	jobRepoFactory            JobRepoFactory
 	dependencyResolver        DependencyResolver
@@ -467,7 +467,7 @@ func jobDeletionFilter(dagNames []string) []string {
 
 // NewService creates a new instance of JobService, requiring
 // the necessary dependencies as arguments
-func NewService(jobSpecRepoFactory JobSpecRepoFactory, jobRepoFact JobRepoFactory,
+func NewService(jobSpecRepoFactory SpecRepoFactory, jobRepoFact JobRepoFactory,
 	compiler models.JobCompiler, assetCompiler AssetCompiler, dependencyResolver DependencyResolver,
 	priorityResolver PriorityResolver, metaSvcFactory meta.MetaSvcFactory,
 	projectJobSpecRepoFactory ProjectJobSpecRepoFactory,

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -26,6 +28,8 @@ var (
 )
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	configuration, err := config.InitOptimus()
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())

--- a/mock/job.go
+++ b/mock/job.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/odpf/optimus/job"
+
 	"github.com/odpf/optimus/core/tree"
 
 	"github.com/odpf/optimus/core/progress"
@@ -56,8 +58,8 @@ type JobSpecRepoFactory struct {
 	mock.Mock
 }
 
-func (repo *JobSpecRepoFactory) New(namespace models.NamespaceSpec) store.JobSpecRepository {
-	return repo.Called(namespace).Get(0).(store.JobSpecRepository)
+func (repo *JobSpecRepoFactory) New(namespace models.NamespaceSpec) job.SpecRepository {
+	return repo.Called(namespace).Get(0).(job.SpecRepository)
 }
 
 // JobSpecRepoFactory to store raw specs

--- a/store/local/job_spec_repository_test.go
+++ b/store/local/job_spec_repository_test.go
@@ -175,7 +175,7 @@ func TestJobSpecRepository(t *testing.T) {
 		})
 		t.Run("should return error if task is empty", func(t *testing.T) {
 			repo := local.NewJobSpecRepository(nil, adapter)
-			err := repo.Save(models.JobSpec{Name: "foo"})
+			err := repo.SaveAt(models.JobSpec{Name: "foo"}, "")
 			assert.NotNil(t, err)
 		})
 		t.Run("should return error if name is empty", func(t *testing.T) {
@@ -368,21 +368,21 @@ task:
 			assert.Nil(t, err)
 			assert.Equal(t, spec2, returnedSpecAgain)
 		})
-		t.Run("should return ErrNoDAGSpecs in case no job folder exist", func(t *testing.T) {
+		t.Run("should return ErrNoSuchSpec in case no job folder exist", func(t *testing.T) {
 			// create test files and directories
 			appFS := afero.NewMemMapFs()
 
 			repo := local.NewJobSpecRepository(appFS, adapter)
 			_, err := repo.GetByName(spec.Name)
-			assert.Equal(t, models.ErrNoDAGSpecs, err)
+			assert.Equal(t, models.ErrNoSuchSpec, err)
 		})
-		t.Run("should return ErrNoDAGSpecs in case the job folder exist but no job file exist", func(t *testing.T) {
+		t.Run("should return ErrNoSuchSpec in case the job folder exist but no job file exist", func(t *testing.T) {
 			appFS := afero.NewMemMapFs()
 			appFS.MkdirAll(spec.Name, 0755)
 
 			repo := local.NewJobSpecRepository(appFS, adapter)
 			_, err := repo.GetByName(spec.Name)
-			assert.Equal(t, models.ErrNoDAGSpecs, err)
+			assert.Equal(t, models.ErrNoSuchSpec, err)
 		})
 		t.Run("should return an error if jobName is empty", func(t *testing.T) {
 			repo := local.NewJobSpecRepository(afero.NewMemMapFs(), nil)

--- a/store/local/resource_spec_repository_test.go
+++ b/store/local/resource_spec_repository_test.go
@@ -85,7 +85,7 @@ func TestResourceSpecRepository(t *testing.T) {
 		})
 		t.Run("should return error if type is empty", func(t *testing.T) {
 			repo := local.NewResourceSpecRepository(nil, datastorer)
-			err := repo.Save(models.ResourceSpec{Name: "foo"})
+			err := repo.SaveAt(models.ResourceSpec{Name: "foo"}, "")
 			assert.NotNil(t, err)
 		})
 		t.Run("should return error if name is empty", func(t *testing.T) {
@@ -127,18 +127,18 @@ func TestResourceSpecRepository(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, specTable, returnedSpecAgain)
 		})
-		t.Run("should return ErrNoResources in case no job folder exist", func(t *testing.T) {
+		t.Run("should return ErrNoSuchSpec in case no job folder exist", func(t *testing.T) {
 			repo := local.NewResourceSpecRepository(afero.NewMemMapFs(), datastorer)
 			_, err := repo.GetByName(specTable.Name)
-			assert.Equal(t, models.ErrNoResources, err)
+			assert.Equal(t, models.ErrNoSuchSpec, err)
 		})
-		t.Run("should return ErrNoResources in case the folder exist but no resource file exist", func(t *testing.T) {
+		t.Run("should return ErrNoSuchSpec in case the folder exist but no resource file exist", func(t *testing.T) {
 			appFS := afero.NewMemMapFs()
 			appFS.MkdirAll(specTable.Name, 0755)
 
 			repo := local.NewResourceSpecRepository(appFS, datastorer)
 			_, err := repo.GetByName(specTable.Name)
-			assert.Equal(t, models.ErrNoResources, err)
+			assert.Equal(t, models.ErrNoSuchSpec, err)
 		})
 		t.Run("should return an error if name is empty", func(t *testing.T) {
 			repo := local.NewResourceSpecRepository(afero.NewMemMapFs(), nil)

--- a/store/postgres/instance_repository_test.go
+++ b/store/postgres/instance_repository_test.go
@@ -117,8 +117,8 @@ func TestInstanceRepository(t *testing.T) {
 		prepo := NewProjectRepository(dbConn, hash)
 		assert.Nil(t, prepo.Save(projectSpec))
 
-		projectJobSpecRepo := NewProjectJobRepository(dbConn, projectSpec, adapter)
-		jrepo := NewJobRepository(dbConn, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(dbConn, projectSpec, adapter)
+		jrepo := NewJobSpecRepository(dbConn, namespaceSpec, projectJobSpecRepo, adapter)
 		assert.Nil(t, jrepo.Save(jobConfigs[0]))
 		assert.Equal(t, "task unit cannot be empty", jrepo.Save(jobConfigs[1]).Error())
 		return dbConn
@@ -147,8 +147,8 @@ func TestInstanceRepository(t *testing.T) {
 		testModels := []models.InstanceSpec{}
 		testModels = append(testModels, testSpecs...)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		jobRepo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		jobRepo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 		err := jobRepo.Insert(testModels[0].Job)
 		assert.Nil(t, err)
 

--- a/store/postgres/job_spec_repository_test.go
+++ b/store/postgres/job_spec_repository_test.go
@@ -167,7 +167,7 @@ func TestJobRepository(t *testing.T) {
 			projectJobSpecRepo := new(mock.ProjectJobSpecRepository)
 			defer projectJobSpecRepo.AssertExpectations(t)
 
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			err := repo.Insert(testModels[0])
 			assert.Nil(t, err)
@@ -210,7 +210,7 @@ func TestJobRepository(t *testing.T) {
 			projectJobSpecRepo := new(mock.ProjectJobSpecRepository)
 			defer projectJobSpecRepo.AssertExpectations(t)
 
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			// first insert
 			err := repo.Insert(testModels[0])
@@ -262,8 +262,8 @@ func TestJobRepository(t *testing.T) {
 			execUnit2.On("GenerateTaskDestination", context.TODO(), unitData2).Return(models.GenerateTaskDestinationResponse{Destination: destination}, nil)
 			defer execUnit2.AssertExpectations(t)
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			//try for create
 			err := repo.Save(testModelA)
@@ -299,8 +299,8 @@ func TestJobRepository(t *testing.T) {
 			execUnit2.On("GenerateTaskDestination", context.TODO(), unitData2).Return(models.GenerateTaskDestinationResponse{Destination: destination}, nil)
 			defer execUnit2.AssertExpectations(t)
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			//try for create
 			testModelA.Task.Unit = execUnit1
@@ -334,8 +334,8 @@ func TestJobRepository(t *testing.T) {
 			testModelA := testConfigs[0]
 			testModelA.ID = uuid.Nil
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			//try for create
 			err := repo.Save(testModelA)
@@ -350,8 +350,8 @@ func TestJobRepository(t *testing.T) {
 			defer db.Close()
 			testModel := testConfigs[2]
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			err := repo.Insert(testModel)
 			assert.Nil(t, err)
@@ -443,9 +443,9 @@ func TestJobRepository(t *testing.T) {
 			execUnit1.On("GenerateTaskDestination", context.TODO(), unitData1).Return(models.GenerateTaskDestinationResponse{Destination: destination}, nil)
 			defer execUnit1.AssertExpectations(t)
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			jobRepoNamespace1 := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
-			jobRepoNamespace2 := NewJobRepository(db, namespaceSpec2, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			jobRepoNamespace1 := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			jobRepoNamespace2 := NewJobSpecRepository(db, namespaceSpec2, projectJobSpecRepo, adapter)
 
 			// try to create with first namespace
 			err := jobRepoNamespace1.Save(testModelA)
@@ -473,8 +473,8 @@ func TestJobRepository(t *testing.T) {
 			execUnit1.On("GenerateTaskDestination", context.TODO(), unitData1).Return(models.GenerateTaskDestinationResponse{Destination: destination}, nil)
 			defer execUnit1.AssertExpectations(t)
 
-			projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-			repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+			projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+			repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 			//try for create
 			err := repo.Save(testModelA)
@@ -508,8 +508,8 @@ func TestJobRepository(t *testing.T) {
 		testModels := []models.JobSpec{}
 		testModels = append(testModels, testConfigs...)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 		err := repo.Insert(testModels[0])
 		assert.Nil(t, err)
@@ -526,8 +526,8 @@ func TestJobRepository(t *testing.T) {
 		testModels := []models.JobSpec{}
 		testModels = append(testModels, testConfigs...)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 		err := repo.Insert(testModels[0])
 		assert.Nil(t, err)
@@ -675,8 +675,8 @@ func TestProjectJobRepository(t *testing.T) {
 		defer execUnit1.AssertExpectations(t)
 		defer execUnit2.AssertExpectations(t)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 		err := repo.Insert(testModels[0])
 		assert.Nil(t, err)
@@ -705,8 +705,8 @@ func TestProjectJobRepository(t *testing.T) {
 		defer execUnit1.AssertExpectations(t)
 		defer execUnit2.AssertExpectations(t)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		repo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		repo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 
 		err := repo.Insert(testModels[0])
 		assert.Nil(t, err)
@@ -734,8 +734,8 @@ func TestProjectJobRepository(t *testing.T) {
 		testModels := []models.JobSpec{}
 		testModels = append(testModels, testConfigs...)
 
-		projectJobSpecRepo := NewProjectJobRepository(db, projectSpec, adapter)
-		jobRepo := NewJobRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
+		projectJobSpecRepo := NewProjectJobSpecRepository(db, projectSpec, adapter)
+		jobRepo := NewJobSpecRepository(db, namespaceSpec, projectJobSpecRepo, adapter)
 		err := jobRepo.Insert(testModels[0])
 		assert.Nil(t, err)
 

--- a/store/postgres/project_repository.go
+++ b/store/postgres/project_repository.go
@@ -71,12 +71,12 @@ func (p Project) ToSpecWithSecrets(h models.ApplicationKey) (models.ProjectSpec,
 	}, nil
 }
 
-type projectRepository struct {
+type ProjectRepository struct {
 	db   *gorm.DB
 	hash models.ApplicationKey
 }
 
-func (repo *projectRepository) Insert(resource models.ProjectSpec) error {
+func (repo *ProjectRepository) Insert(resource models.ProjectSpec) error {
 	p, err := Project{}.FromSpec(resource)
 	if err != nil {
 		return err
@@ -87,7 +87,7 @@ func (repo *projectRepository) Insert(resource models.ProjectSpec) error {
 	return repo.db.Create(&p).Error
 }
 
-func (repo *projectRepository) Save(spec models.ProjectSpec) error {
+func (repo *ProjectRepository) Save(spec models.ProjectSpec) error {
 	existingResource, err := repo.GetByName(spec.Name)
 	if errors.Is(err, store.ErrResourceNotFound) {
 		return repo.Insert(spec)
@@ -102,7 +102,7 @@ func (repo *projectRepository) Save(spec models.ProjectSpec) error {
 	return repo.db.Model(project).Updates(project).Error
 }
 
-func (repo *projectRepository) GetByName(name string) (models.ProjectSpec, error) {
+func (repo *ProjectRepository) GetByName(name string) (models.ProjectSpec, error) {
 	var r Project
 	if err := repo.db.Preload("Secrets").Where("name = ?", name).Find(&r).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -113,7 +113,7 @@ func (repo *projectRepository) GetByName(name string) (models.ProjectSpec, error
 	return r.ToSpecWithSecrets(repo.hash)
 }
 
-func (repo *projectRepository) GetByID(id uuid.UUID) (models.ProjectSpec, error) {
+func (repo *ProjectRepository) GetByID(id uuid.UUID) (models.ProjectSpec, error) {
 	var r Project
 	if err := repo.db.Preload("Secrets").Where("id = ?", id).Find(&r).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -124,7 +124,7 @@ func (repo *projectRepository) GetByID(id uuid.UUID) (models.ProjectSpec, error)
 	return r.ToSpecWithSecrets(repo.hash)
 }
 
-func (repo *projectRepository) GetAll() ([]models.ProjectSpec, error) {
+func (repo *ProjectRepository) GetAll() ([]models.ProjectSpec, error) {
 	specs := []models.ProjectSpec{}
 	projs := []Project{}
 	if err := repo.db.Preload("Secrets").Find(&projs).Error; err != nil {
@@ -140,8 +140,8 @@ func (repo *projectRepository) GetAll() ([]models.ProjectSpec, error) {
 	return specs, nil
 }
 
-func NewProjectRepository(db *gorm.DB, hash models.ApplicationKey) *projectRepository {
-	return &projectRepository{
+func NewProjectRepository(db *gorm.DB, hash models.ApplicationKey) *ProjectRepository {
+	return &ProjectRepository{
 		db:   db,
 		hash: hash,
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -20,14 +20,6 @@ type ProjectJobSpecRepository interface {
 	GetByDestination(string) (models.JobSpec, models.ProjectSpec, error)
 }
 
-// JobSpecRepository represents a storage interface for Job specifications at a namespace level
-type JobSpecRepository interface {
-	Save(models.JobSpec) error
-	GetByName(string) (models.JobSpec, error)
-	GetAll() ([]models.JobSpec, error)
-	Delete(string) error
-}
-
 // ProjectRepository represents a storage interface for registered projects
 type ProjectRepository interface {
 	Save(models.ProjectSpec) error

--- a/utils/contains.go
+++ b/utils/contains.go
@@ -1,0 +1,11 @@
+package utils
+
+// ContainsString returns true if a string is present in string slice
+func ContainsString(s []string, v string) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/contains_test.go
+++ b/utils/contains_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import "testing"
+
+func TestContainsString(t *testing.T) {
+	type args struct {
+		s []string
+		v string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should found an item if present",
+			args: args{
+				s: []string{"a", "abc", "d"},
+				v: "abc",
+			},
+			want: true,
+		},
+		{
+			name: "should not found an item if not present",
+			args: args{
+				s: []string{"a", "abc", "d"},
+				v: "abcd",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsString(tt.args.s, tt.args.v); got != tt.want {
+				t.Errorf("ContainsString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Users should be able to select directories when a new job or resource is created. Adding a new question to CLI that will ask directories(and sub directories if needed) to find where exactly the spec should be created instead of creating them at the root all the time.