### PR TITLE
feat: support static inter project dependencies

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -355,16 +355,16 @@ func Initialize(l log.Logger, conf config.Provider) error {
 		db:   dbConn,
 		hash: appHash,
 	}
-	projectJobSpecRepoFac := projectJobSpecRepoFactory{
+	projectJobSpecRepoFac := &projectJobSpecRepoFactory{
 		db: dbConn,
 	}
 
 	// registered job store repository factory
 	jobSpecRepoFac := jobSpecRepoFactory{
 		db:                    dbConn,
-		projectJobSpecRepoFac: projectJobSpecRepoFac,
+		projectJobSpecRepoFac: *projectJobSpecRepoFac,
 	}
-	dependencyResolver := job.NewDependencyResolver()
+	dependencyResolver := job.NewDependencyResolver(projectJobSpecRepoFac)
 	priorityResolver := job.NewPriorityResolver()
 
 	// Logrus entry is used, allowing pre-definition of certain fields by the user.
@@ -459,7 +459,7 @@ func Initialize(l log.Logger, conf config.Provider) error {
 			dependencyResolver,
 			priorityResolver,
 			metaSvcFactory,
-			&projectJobSpecRepoFac,
+			projectJobSpecRepoFac,
 			replayManager,
 		),
 		eventService,

--- a/docs/docs/concepts/overview.md
+++ b/docs/docs/concepts/overview.md
@@ -192,7 +192,12 @@ dependencies:
     # extra: outside optimus[not properly supported]
     # optional, default: intra
     type: intra
-
+    
+  - # inter dependencies should prefix job name with project name divided by
+    # a forward slash <external_project_name>/<external_job_name>
+    job: cross_project/sample_external_job
+    type: inter
+  
 # adhoc operations marked for execution at different hook points
 # accepts a list
 hooks:

--- a/job/dependency_resolver_test.go
+++ b/job/dependency_resolver_test.go
@@ -95,6 +95,10 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository.On("GetByDestination", "project.dataset.table2_destination").Return(jobSpec2, projectSpec, nil)
 			defer jobSpecRepository.AssertExpectations(t)
 
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
 			unitData := models.GenerateDependenciesRequest{
 				Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets),
 				Project: projectSpec,
@@ -117,10 +121,10 @@ func TestDependencyResolver(t *testing.T) {
 				DependsOn: []string{"hook1"},
 			}, nil)
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 			assert.Nil(t, err)
-			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec2, nil)
+			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
 			assert.Nil(t, err)
 
 			assert.Equal(t, map[string]models.JobSpecDependency{
@@ -195,6 +199,10 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository.On("GetByDestination", "project.dataset.table2_destination").Return(jobSpec2, projectSpec, nil)
 			defer jobSpecRepository.AssertExpectations(t)
 
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
 			unitData := models.GenerateDependenciesRequest{
 				Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets),
 				Project: projectSpec,
@@ -209,10 +217,10 @@ func TestDependencyResolver(t *testing.T) {
 			}, nil)
 			execUnit.On("GenerateDependencies", context.TODO(), unitData2).Return(&models.GenerateDependenciesResponse{}, nil)
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 			assert.Nil(t, err)
-			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec2, nil)
+			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
 			assert.Nil(t, err)
 
 			assert.Equal(t, map[string]models.JobSpecDependency{
@@ -269,12 +277,16 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository.On("GetByDestination", "project.dataset.table2_destination").Return(jobSpec2, projectSpec, errors.New("random error"))
 			defer jobSpecRepository.AssertExpectations(t)
 
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
 			unitData := models.GenerateDependenciesRequest{Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets), Project: projectSpec}
 			execUnit.On("GenerateDependencies", context.Background(), unitData).Return(
 				&models.GenerateDependenciesResponse{Dependencies: []string{"project.dataset.table2_destination"}}, nil)
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 
 			assert.Error(t, errors.Wrapf(errors.New("random error"), job.UnknownRuntimeDependencyMessage,
 				"project.dataset.table2_destination", jobSpec1.Name),
@@ -308,12 +320,15 @@ func TestDependencyResolver(t *testing.T) {
 
 			jobSpecRepository := new(mock.ProjectJobSpecRepository)
 			defer jobSpecRepository.AssertExpectations(t)
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
 
 			unitData := models.GenerateDependenciesRequest{Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets), Project: projectSpec}
 			execUnit.On("GenerateDependencies", context.Background(), unitData).Return(&models.GenerateDependenciesResponse{}, errors.New("random error"))
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 
 			assert.Equal(t, "random error", err.Error())
 			assert.Equal(t, models.JobSpec{}, resolvedJobSpec1)
@@ -347,12 +362,16 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository.On("GetByDestination", "project.dataset.table3_destination").Return(nil, nil, errors.New("spec not found"))
 			defer jobSpecRepository.AssertExpectations(t)
 
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
 			unitData := models.GenerateDependenciesRequest{Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets), Project: projectSpec}
 			execUnit.On("GenerateDependencies", context.Background(), unitData).Return(&models.GenerateDependenciesResponse{
 				Dependencies: []string{"project.dataset.table3_destination"}}, nil)
 
-			resolver := job.NewDependencyResolver()
-			_, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			_, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 			assert.Error(t, errors.Wrapf(errors.New("spec not found"), job.UnknownRuntimeDependencyMessage,
 				"project.dataset.table3_destination", jobSpec1.Name),
 				err.Error())
@@ -398,25 +417,88 @@ func TestDependencyResolver(t *testing.T) {
 						},
 					},
 				},
-				Dependencies: map[string]models.JobSpecDependency{"static_dep": {Job: nil}},
+				Dependencies: map[string]models.JobSpecDependency{"static_dep": {Job: nil, Type: models.JobSpecDependencyTypeIntra}},
 			}
 
 			jobSpecRepository := new(mock.ProjectJobSpecRepository)
 			jobSpecRepository.On("GetByDestination", "project.dataset.table1_destination").Return(jobSpec1, projectSpec, nil)
 			jobSpecRepository.On("GetByName", "static_dep").Return(nil, errors.New("spec not found"))
 			defer jobSpecRepository.AssertExpectations(t)
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
 
 			unitData2 := models.GenerateDependenciesRequest{Config: models.PluginConfigs{}.FromJobSpec(jobSpec2.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec2.Assets), Project: projectSpec}
 			execUnit.On("GenerateDependencies", context.Background(), unitData2).Return(&models.GenerateDependenciesResponse{
 				Dependencies: []string{"project.dataset.table1_destination"},
 			}, nil)
 
-			resolver := job.NewDependencyResolver()
-			_, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec2, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			_, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
 			assert.Equal(t, "unknown local dependency for job static_dep: spec not found", err.Error())
 		})
 
-		t.Run("it should resolve any unresolved static dependency", func(t *testing.T) {
+		t.Run("it should fail for unknown static dependency type", func(t *testing.T) {
+			execUnit := new(mock.DependencyResolverMod)
+			defer execUnit.AssertExpectations(t)
+
+			jobSpec1 := models.JobSpec{
+				Version: 1,
+				Name:    "test1",
+				Owner:   "optimus",
+				Schedule: models.JobSpecSchedule{
+					StartDate: time.Date(2020, 12, 02, 0, 0, 0, 0, time.UTC),
+					Interval:  "@daily",
+				},
+				Task: models.JobSpecTask{
+					Unit: &models.Plugin{DependencyMod: execUnit},
+					Config: models.JobSpecConfigs{
+						{
+							Name:  "foo",
+							Value: "bar",
+						},
+					},
+				},
+				Dependencies: make(map[string]models.JobSpecDependency),
+			}
+			jobSpec2 := models.JobSpec{
+				Version: 1,
+				Name:    "test2",
+				Owner:   "optimus",
+				Schedule: models.JobSpecSchedule{
+					StartDate: time.Date(2020, 12, 02, 0, 0, 0, 0, time.UTC),
+					Interval:  "@daily",
+				},
+				Task: models.JobSpecTask{
+					Unit: &models.Plugin{DependencyMod: execUnit},
+					Config: models.JobSpecConfigs{
+						{
+							Name:  "foo",
+							Value: "baz",
+						},
+					},
+				},
+				Dependencies: map[string]models.JobSpecDependency{"static_dep": {Job: nil, Type: "bad"}},
+			}
+
+			jobSpecRepository := new(mock.ProjectJobSpecRepository)
+			jobSpecRepository.On("GetByDestination", "project.dataset.table1_destination").Return(jobSpec1, projectSpec, nil)
+			defer jobSpecRepository.AssertExpectations(t)
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
+			unitData2 := models.GenerateDependenciesRequest{Config: models.PluginConfigs{}.FromJobSpec(jobSpec2.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec2.Assets), Project: projectSpec}
+			execUnit.On("GenerateDependencies", context.Background(), unitData2).Return(&models.GenerateDependenciesResponse{
+				Dependencies: []string{"project.dataset.table1_destination"},
+			}, nil)
+
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			_, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
+			assert.Equal(t, "unsupported dependency type: bad", err.Error())
+		})
+
+		t.Run("it should resolve any unresolved intra static dependency", func(t *testing.T) {
 			execUnit := new(mock.DependencyResolverMod)
 			defer execUnit.AssertExpectations(t)
 
@@ -484,6 +566,10 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository.On("GetByName", "test3").Return(jobSpec3, namespaceSpec, nil)
 			defer jobSpecRepository.AssertExpectations(t)
 
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
+
 			unitData := models.GenerateDependenciesRequest{
 				Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets),
 				Project: projectSpec,
@@ -498,10 +584,10 @@ func TestDependencyResolver(t *testing.T) {
 			}, nil)
 			execUnit.On("GenerateDependencies", context.Background(), unitData2).Return(&models.GenerateDependenciesResponse{}, nil)
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 			assert.Nil(t, err)
-			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec2, nil)
+			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
 			assert.Nil(t, err)
 
 			assert.Nil(t, err)
@@ -512,7 +598,7 @@ func TestDependencyResolver(t *testing.T) {
 			assert.Equal(t, map[string]models.JobSpecDependency{}, resolvedJobSpec2.Dependencies)
 		})
 
-		t.Run("it should resolve any inter dependency", func(t *testing.T) {
+		t.Run("it should resolve any static inter dependency and intra inferred dependency", func(t *testing.T) {
 			externalProjectName := "an-external-data-project"
 			externalProjectSpec := models.ProjectSpec{
 				Name: externalProjectName,
@@ -560,9 +646,11 @@ func TestDependencyResolver(t *testing.T) {
 						},
 					},
 				},
-				Dependencies: map[string]models.JobSpecDependency{"test3": {Job: nil, Type: models.JobSpecDependencyTypeIntra}},
-				// explicitly setting a dirty dependency
+				// explicitly setting a dirty intra dependency
+				Dependencies: map[string]models.JobSpecDependency{externalProjectName + "/" + jobSpec3.Name: {Job: nil, Type: models.JobSpecDependencyTypeInter}},
 			}
+
+			// destination: project.dataset.table2_destination
 			jobSpec2 := models.JobSpec{
 				Version: 1,
 				Name:    "test2",
@@ -582,6 +670,8 @@ func TestDependencyResolver(t *testing.T) {
 				},
 				Dependencies: make(map[string]models.JobSpecDependency),
 			}
+
+			// destination: project.dataset.table2_external_destination
 			jobSpecExternal := models.JobSpec{
 				Version: 1,
 				Name:    "test2-external",
@@ -605,8 +695,12 @@ func TestDependencyResolver(t *testing.T) {
 			jobSpecRepository := new(mock.ProjectJobSpecRepository)
 			jobSpecRepository.On("GetByDestination", "project.dataset.table2_destination").Return(jobSpec2, projectSpec, nil)
 			jobSpecRepository.On("GetByDestination", "project.dataset.table2_external_destination").Return(jobSpecExternal, externalProjectSpec, nil)
-			jobSpecRepository.On("GetByName", "test3").Return(jobSpec3, namespaceSpec, nil)
+			jobSpecRepository.On("GetByNameForProject", externalProjectName, "test3").Return(jobSpec3, externalProjectSpec, nil)
 			defer jobSpecRepository.AssertExpectations(t)
+
+			projectJobSpecRepoFactory := new(mock.ProjectJobSpecRepoFactory)
+			projectJobSpecRepoFactory.On("New", projectSpec).Return(jobSpecRepository)
+			defer projectJobSpecRepoFactory.AssertExpectations(t)
 
 			unitData := models.GenerateDependenciesRequest{
 				Config: models.PluginConfigs{}.FromJobSpec(jobSpec1.Task.Config), Assets: models.PluginAssets{}.FromJobSpec(jobSpec1.Assets),
@@ -625,16 +719,16 @@ func TestDependencyResolver(t *testing.T) {
 			}, nil)
 			execUnit.On("GenerateDependencies", context.Background(), unitData2).Return(&models.GenerateDependenciesResponse{}, nil)
 
-			resolver := job.NewDependencyResolver()
-			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec1, nil)
+			resolver := job.NewDependencyResolver(projectJobSpecRepoFactory)
+			resolvedJobSpec1, err := resolver.Resolve(ctx, projectSpec, jobSpec1, nil)
 			assert.Nil(t, err)
-			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpecRepository, jobSpec2, nil)
+			resolvedJobSpec2, err := resolver.Resolve(ctx, projectSpec, jobSpec2, nil)
 			assert.Nil(t, err)
 
 			assert.Nil(t, err)
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec2, Project: &projectSpec, Type: models.JobSpecDependencyTypeIntra}, resolvedJobSpec1.Dependencies[jobSpec2.Name])
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpecExternal, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[jobSpecExternal.Name])
-			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &projectSpec, Type: models.JobSpecDependencyTypeIntra}, resolvedJobSpec1.Dependencies[jobSpec3.Name])
+			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[externalProjectName+"/"+jobSpec3.Name])
 			assert.Equal(t, map[string]models.JobSpecDependency{}, resolvedJobSpec2.Dependencies)
 		})
 	})

--- a/job/replay_test.go
+++ b/job/replay_test.go
@@ -130,12 +130,12 @@ func TestReplay(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[0], nil).Return(models.JobSpec{}, errors.New("error while fetching dag1"))
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[1], nil).Return(dagSpec[1], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[2], nil).Return(dagSpec[2], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[3], nil).Return(models.JobSpec{}, errors.New("error while fetching dag3"))
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[4], nil).Return(models.JobSpec{}, errors.New("error while fetching dag4"))
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[5], nil).Return(dagSpec[5], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[0], nil).Return(models.JobSpec{}, errors.New("error while fetching dag1"))
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[1], nil).Return(dagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[2], nil).Return(dagSpec[2], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[3], nil).Return(models.JobSpec{}, errors.New("error while fetching dag3"))
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[4], nil).Return(models.JobSpec{}, errors.New("error while fetching dag4"))
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[5], nil).Return(dagSpec[5], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			replayStart, _ := time.Parse(job.ReplayDateFormat, "2020-08-05")
@@ -177,8 +177,8 @@ func TestReplay(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, cyclicDagSpec[0], nil).Return(cyclicDagSpec[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, cyclicDagSpec[1], nil).Return(cyclicDagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, cyclicDagSpec[0], nil).Return(cyclicDagSpec[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, cyclicDagSpec[1], nil).Return(cyclicDagSpec[1], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			replayStart, _ := time.Parse(job.ReplayDateFormat, "2020-08-05")
@@ -208,12 +208,12 @@ func TestReplay(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[0], nil).Return(dagSpec[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[1], nil).Return(dagSpec[1], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[2], nil).Return(dagSpec[2], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[3], nil).Return(dagSpec[3], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[4], nil).Return(dagSpec[4], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[5], nil).Return(dagSpec[5], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[0], nil).Return(dagSpec[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[1], nil).Return(dagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[2], nil).Return(dagSpec[2], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[3], nil).Return(dagSpec[3], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[4], nil).Return(dagSpec[4], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[5], nil).Return(dagSpec[5], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			jobSvc := job.NewService(nil, nil, nil, dumpAssets, depenResolver, nil, nil, projJobSpecRepoFac, nil)
@@ -257,12 +257,12 @@ func TestReplay(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[0], nil).Return(dagSpec[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[1], nil).Return(dagSpec[1], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[2], nil).Return(dagSpec[2], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[3], nil).Return(dagSpec[3], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[4], nil).Return(dagSpec[4], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[5], nil).Return(dagSpec[5], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[0], nil).Return(dagSpec[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[1], nil).Return(dagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[2], nil).Return(dagSpec[2], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[3], nil).Return(dagSpec[3], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[4], nil).Return(dagSpec[4], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[5], nil).Return(dagSpec[5], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			jobSvc := job.NewService(nil, nil, nil, dumpAssets, depenResolver, nil, nil, projJobSpecRepoFac, nil)
@@ -333,12 +333,12 @@ func TestReplay(t *testing.T) {
 			defer projJobSpecRepoFac.AssertExpectations(t)
 
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[0], nil).Return(dagSpec[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[1], nil).Return(dagSpec[1], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[2], nil).Return(dagSpec[2], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[3], nil).Return(dagSpec[3], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[4], nil).Return(dagSpec[4], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[5], nil).Return(dagSpec[5], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[0], nil).Return(dagSpec[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[1], nil).Return(dagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[2], nil).Return(dagSpec[2], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[3], nil).Return(dagSpec[3], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[4], nil).Return(dagSpec[4], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[5], nil).Return(dagSpec[5], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			replayStart, _ := time.Parse(job.ReplayDateFormat, "2020-08-05")
@@ -373,12 +373,12 @@ func TestReplay(t *testing.T) {
 			defer projJobSpecRepoFac.AssertExpectations(t)
 
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[0], nil).Return(dagSpec[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[1], nil).Return(dagSpec[1], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[2], nil).Return(dagSpec[2], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[3], nil).Return(dagSpec[3], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[4], nil).Return(dagSpec[4], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, dagSpec[5], nil).Return(dagSpec[5], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[0], nil).Return(dagSpec[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[1], nil).Return(dagSpec[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[2], nil).Return(dagSpec[2], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[3], nil).Return(dagSpec[3], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[4], nil).Return(dagSpec[4], nil)
+			depenResolver.On("Resolve", ctx, projSpec, dagSpec[5], nil).Return(dagSpec[5], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			replayStart, _ := time.Parse(job.ReplayDateFormat, "2020-08-05")

--- a/job/service.go
+++ b/job/service.go
@@ -30,8 +30,7 @@ type AssetCompiler func(jobSpec models.JobSpec, scheduledAt time.Time) (models.J
 
 // DependencyResolver compiles static and runtime dependencies
 type DependencyResolver interface {
-	Resolve(ctx context.Context, projectSpec models.ProjectSpec, projectJobSpecRepo store.ProjectJobSpecRepository,
-		jobSpec models.JobSpec, observer progress.Observer) (models.JobSpec, error)
+	Resolve(ctx context.Context, projectSpec models.ProjectSpec, jobSpec models.JobSpec, observer progress.Observer) (models.JobSpec, error)
 }
 
 // SpecRepoFactory is used to manage job specs at namespace level
@@ -326,7 +325,7 @@ func (srv *Service) GetDependencyResolvedSpecs(ctx context.Context, proj models.
 	for _, jobSpec := range jobSpecs {
 		runner.Add(func(currentSpec models.JobSpec) func() (interface{}, error) {
 			return func() (interface{}, error) {
-				resolvedSpec, err := srv.dependencyResolver.Resolve(ctx, proj, projectJobSpecRepo, currentSpec, progressObserver)
+				resolvedSpec, err := srv.dependencyResolver.Resolve(ctx, proj, currentSpec, progressObserver)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to resolve dependency for %s", currentSpec.Name)
 				}

--- a/job/service_test.go
+++ b/job/service_test.go
@@ -231,7 +231,7 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			// resolve priority
@@ -317,7 +317,7 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			// resolve priority
@@ -377,8 +377,8 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(models.JobSpec{}, errors.New("error test"))
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[1], nil).Return(models.JobSpec{},
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(models.JobSpec{}, errors.New("error test"))
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[1], nil).Return(models.JobSpec{},
 				errors.New("error test-2"))
 			defer depenResolver.AssertExpectations(t)
 
@@ -454,7 +454,7 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			// resolve priority
@@ -616,7 +616,7 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			batchScheduler := new(mock.Scheduler)
@@ -694,8 +694,8 @@ func TestService(t *testing.T) {
 
 			// resolve dependencies
 			depenResolver := new(mock.DependencyResolver)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpecsBase[1], nil).Return(jobSpecsAfterDepenResolve[1], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[0], nil).Return(jobSpecsAfterDepenResolve[0], nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpecsBase[1], nil).Return(jobSpecsAfterDepenResolve[1], nil)
 			defer depenResolver.AssertExpectations(t)
 
 			batchScheduler := new(mock.Scheduler)
@@ -771,8 +771,8 @@ func TestService(t *testing.T) {
 
 			depenResolver := new(mock.DependencyResolver)
 			defer depenResolver.AssertExpectations(t)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpec1, nil).Return(jobSpec1, nil)
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpec2, nil).Return(jobSpec2, nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpec1, nil).Return(jobSpec1, nil)
+			depenResolver.On("Resolve", ctx, projSpec, jobSpec2, nil).Return(jobSpec2, nil)
 
 			svc := job.NewService(nil, nil, nil, dumpAssets, depenResolver, nil, nil, projJobSpecRepoFac, nil)
 			jobSpecsResult, err := svc.GetDownstream(ctx, projSpec, jobSpec1.Name)
@@ -827,8 +827,8 @@ func TestService(t *testing.T) {
 			depenResolver := new(mock.DependencyResolver)
 			defer depenResolver.AssertExpectations(t)
 			errorMsg := "unable to resolve dependency"
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpec1, nil).Return(models.JobSpec{}, errors.New(errorMsg))
-			depenResolver.On("Resolve", ctx, projSpec, projectJobSpecRepo, jobSpec2, nil).Return(models.JobSpec{}, errors.New(errorMsg))
+			depenResolver.On("Resolve", ctx, projSpec, jobSpec1, nil).Return(models.JobSpec{}, errors.New(errorMsg))
+			depenResolver.On("Resolve", ctx, projSpec, jobSpec2, nil).Return(models.JobSpec{}, errors.New(errorMsg))
 
 			svc := job.NewService(nil, nil, nil, dumpAssets, depenResolver, nil, nil, projJobSpecRepoFac, nil)
 			jobSpecsResult, err := svc.GetDownstream(ctx, projSpec, destination)

--- a/mock/job.go
+++ b/mock/job.go
@@ -38,6 +38,14 @@ func (repo *ProjectJobSpecRepository) GetByName(name string) (models.JobSpec, mo
 	return models.JobSpec{}, models.NamespaceSpec{}, args.Error(1)
 }
 
+func (repo *ProjectJobSpecRepository) GetByNameForProject(job, project string) (models.JobSpec, models.ProjectSpec, error) {
+	args := repo.Called(job, project)
+	if args.Get(0) != nil {
+		return args.Get(0).(models.JobSpec), args.Get(1).(models.ProjectSpec), args.Error(2)
+	}
+	return models.JobSpec{}, models.ProjectSpec{}, args.Error(1)
+}
+
 func (repo *ProjectJobSpecRepository) GetAll() ([]models.JobSpec, error) {
 	args := repo.Called()
 	if args.Get(0) != nil {
@@ -192,9 +200,9 @@ type DependencyResolver struct {
 	mock.Mock
 }
 
-func (srv *DependencyResolver) Resolve(ctx context.Context, projectSpec models.ProjectSpec, projectJobSpecRepo store.ProjectJobSpecRepository,
+func (srv *DependencyResolver) Resolve(ctx context.Context, projectSpec models.ProjectSpec,
 	jobSpec models.JobSpec, obs progress.Observer) (models.JobSpec, error) {
-	args := srv.Called(ctx, projectSpec, projectJobSpecRepo, jobSpec, obs)
+	args := srv.Called(ctx, projectSpec, jobSpec, obs)
 	return args.Get(0).(models.JobSpec), args.Error(1)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -16,6 +16,7 @@ var (
 // ProjectJobSpecRepository represents a storage interface for Job specifications at a project level
 type ProjectJobSpecRepository interface {
 	GetByName(string) (models.JobSpec, models.NamespaceSpec, error)
+	GetByNameForProject(projectName, jobName string) (models.JobSpec, models.ProjectSpec, error)
 	GetAll() ([]models.JobSpec, error)
 	GetByDestination(string) (models.JobSpec, models.ProjectSpec, error)
 }


### PR DESCRIPTION
Support for cross-project static inter dependencies in job.
```yaml
# ... rest of the job spec
#
#
# static dependencies that can be used to wait for upstream job to finish
# before this job can be started for execution 
dependencies:

  # list `job: <jobname>`
  - job: sample_internal_job
    # provide where the upstream dependency is stored, intra/inter/extra
    # intra: within this project
    # inter: within optimus but cross project
    # extra: outside optimus[not properly supported]
    # optional, default: intra
    type: intra
    
  - # inter dependencies should prefix job name with project name divided by
    # a forward slash <external_project_name>/<external_job_name>
    job: cross_project/sample_external_job
    type: inter
```