### PR TITLE
fix: dependency resolution during duplicate destinations of job

### DIFF
--- a/job/service.go
+++ b/job/service.go
@@ -446,11 +446,16 @@ func (srv *Service) isJobDeletable(ctx context.Context, projectSpec models.Proje
 func (srv *Service) GetByDestination(ctx context.Context, projectSpec models.ProjectSpec, destination string) (models.JobSpec, error) {
 	// generate job spec using datastore destination. if a destination can be owned by multiple jobs, need to change to list
 	projectJobSpecRepo := srv.projectJobSpecRepoFactory.New(projectSpec)
-	jobSpec, _, err := projectJobSpecRepo.GetByDestination(ctx, destination)
+	projectJobPairs, err := projectJobSpecRepo.GetByDestination(ctx, destination)
 	if err != nil {
 		return models.JobSpec{}, err
 	}
-	return jobSpec, nil
+	for _, p := range projectJobPairs {
+		if p.Project.Name == projectSpec.Name {
+			return p.Job, nil
+		}
+	}
+	return models.JobSpec{}, store.ErrResourceNotFound
 }
 
 func (srv *Service) GetDownstream(ctx context.Context, projectSpec models.ProjectSpec, rootJobName string) ([]models.JobSpec, error) {

--- a/job/service_test.go
+++ b/job/service_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/odpf/optimus/store"
+
 	"github.com/google/uuid"
 	"github.com/odpf/optimus/job"
 	"github.com/odpf/optimus/mock"
@@ -984,7 +986,12 @@ func TestService(t *testing.T) {
 
 			projectJobSpecRepo := new(mock.ProjectJobSpecRepository)
 			defer projectJobSpecRepo.AssertExpectations(t)
-			projectJobSpecRepo.On("GetByDestination", ctx, destination).Return(jobSpec1, models.ProjectSpec{}, nil)
+			projectJobSpecRepo.On("GetByDestination", ctx, destination).Return([]store.ProjectJobPair{
+				{
+					Project: projSpec,
+					Job:     jobSpec1,
+				},
+			}, nil)
 
 			projJobSpecRepoFac := new(mock.ProjectJobSpecRepoFactory)
 			defer projJobSpecRepoFac.AssertExpectations(t)
@@ -1004,7 +1011,7 @@ func TestService(t *testing.T) {
 			projectJobSpecRepo := new(mock.ProjectJobSpecRepository)
 			defer projectJobSpecRepo.AssertExpectations(t)
 			errorMsg := "unable to fetch jobspec"
-			projectJobSpecRepo.On("GetByDestination", ctx, destination).Return(models.JobSpec{}, models.ProjectSpec{}, errors.New(errorMsg))
+			projectJobSpecRepo.On("GetByDestination", ctx, destination).Return(nil, errors.New(errorMsg))
 
 			projJobSpecRepoFac := new(mock.ProjectJobSpecRepoFactory)
 			defer projJobSpecRepoFac.AssertExpectations(t)

--- a/mock/job.go
+++ b/mock/job.go
@@ -52,20 +52,12 @@ func (repo *ProjectJobSpecRepository) GetAll(ctx context.Context) ([]models.JobS
 	return []models.JobSpec{}, args.Error(1)
 }
 
-func (repo *ProjectJobSpecRepository) GetAllWithNamespace(ctx context.Context) (map[string][]string, error) {
-	args := repo.Called(ctx)
-	if args.Get(0) != nil {
-		return args.Get(0).(map[string][]string), args.Error(1)
-	}
-	return map[string][]string{}, args.Error(1)
-}
-
-func (repo *ProjectJobSpecRepository) GetByDestination(ctx context.Context, dest string) (models.JobSpec, models.ProjectSpec, error) {
+func (repo *ProjectJobSpecRepository) GetByDestination(ctx context.Context, dest string) ([]store.ProjectJobPair, error) {
 	args := repo.Called(ctx, dest)
 	if args.Get(0) != nil {
-		return args.Get(0).(models.JobSpec), args.Get(1).(models.ProjectSpec), args.Error(2)
+		return args.Get(0).([]store.ProjectJobPair), args.Error(1)
 	}
-	return models.JobSpec{}, models.ProjectSpec{}, args.Error(2)
+	return nil, args.Error(1)
 }
 
 func (repo *ProjectJobSpecRepository) GetJobNamespaces(ctx context.Context) (map[string][]string, error) {

--- a/store/postgres/job_spec_repository_test.go
+++ b/store/postgres/job_spec_repository_test.go
@@ -777,7 +777,7 @@ func TestProjectJobRepository(t *testing.T) {
 			Config: models.PluginConfigs{}.FromJobSpec(testConfigs[0].Task.Config),
 			Assets: models.PluginAssets{}.FromJobSpec(testConfigs[0].Assets),
 		}
-		depMod.On("GenerateDestination", context.TODO(), unitData1).Return(
+		depMod.On("GenerateDestination", ctx, unitData1).Return(
 			&models.GenerateDestinationResponse{Destination: destination, Type: models.DestinationTypeBigquery}, nil)
 		defer depMod.AssertExpectations(t)
 		defer execUnit1.AssertExpectations(t)
@@ -791,10 +791,10 @@ func TestProjectJobRepository(t *testing.T) {
 		err := jobRepo.Insert(ctx, testModels[0])
 		assert.Nil(t, err)
 
-		j, p, err := projectJobSpecRepo.GetByDestination(ctx, destinationUrn)
+		pairs, err := projectJobSpecRepo.GetByDestination(ctx, destinationUrn)
 		assert.Nil(t, err)
-		assert.Equal(t, testConfigs[0].Name, j.Name)
-		assert.Equal(t, projectSpec.Name, p.Name)
+		assert.Equal(t, testConfigs[0].Name, pairs[0].Job.Name)
+		assert.Equal(t, projectSpec.Name, pairs[0].Project.Name)
 	})
 
 	t.Run("GetByNameForProject", func(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -15,12 +15,21 @@ var (
 	ErrEmptyConfig      = errors.New("empty config")
 )
 
+type ProjectJobPair struct {
+	Project models.ProjectSpec
+	Job     models.JobSpec
+}
+
 // ProjectJobSpecRepository represents a storage interface for Job specifications at a project level
 type ProjectJobSpecRepository interface {
 	GetByName(context.Context, string) (models.JobSpec, models.NamespaceSpec, error)
 	GetByNameForProject(ctx context.Context, projectName, jobName string) (models.JobSpec, models.ProjectSpec, error)
 	GetAll(context.Context) ([]models.JobSpec, error)
-	GetByDestination(context.Context, string) (models.JobSpec, models.ProjectSpec, error)
+
+	// GetByDestination returns all the jobs matches with this destination
+	// it can be from current project or from different projects
+	// note: be warned to handle this carefully in multi tenant situations
+	GetByDestination(context.Context, string) ([]ProjectJobPair, error)
 
 	// GetJobNamespaces returns [namespace name] -> []{job name,...} in a project
 	GetJobNamespaces(ctx context.Context) (map[string][]string, error)


### PR DESCRIPTION
https://github.com/odpf/optimus/issues/89

if during dependency resolution, multiple jobs have same destination it should give higher priority to select a job that belongs to the same project first, then choose anyone from the rest if not found.