### PR TITLE
feat: add dagrun_timeout to airflow dag

### DIFF
--- a/ext/scheduler/airflow/resources/base_dag.py
+++ b/ext/scheduler/airflow/resources/base_dag.py
@@ -16,6 +16,7 @@ SENSOR_DEFAULT_POKE_INTERVAL_IN_SECS = int(Variable.get("sensor_poke_interval_in
 SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", default_var=15 * 60 * 60))
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
+DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
 
 default_args = {
     "params": {
@@ -41,7 +42,8 @@ dag = DAG(
     default_args=default_args,
     schedule_interval={{ if eq .Job.Schedule.Interval "" }}None{{- else -}} {{ .Job.Schedule.Interval | quote}}{{end}},
     sla_miss_callback=optimus_sla_miss_notify,
-    catchup ={{ if .Job.Behavior.CatchUp }} True{{ else }} False{{ end }}
+    catchup={{ if .Job.Behavior.CatchUp }}True{{ else }}False{{ end }},
+    dagrun_timeout=timedelta(seconds=DAGRUN_TIMEOUT_IN_SECS)
 )
 
 {{$baseTaskSchema := .Job.Task.Unit.Info -}}

--- a/ext/scheduler/airflow/resources/expected_compiled_template.py
+++ b/ext/scheduler/airflow/resources/expected_compiled_template.py
@@ -16,6 +16,7 @@ SENSOR_DEFAULT_POKE_INTERVAL_IN_SECS = int(Variable.get("sensor_poke_interval_in
 SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", default_var=15 * 60 * 60))
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
+DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
 
 default_args = {
     "params": {
@@ -41,7 +42,8 @@ dag = DAG(
     default_args=default_args,
     schedule_interval="* * * * *",
     sla_miss_callback=optimus_sla_miss_notify,
-    catchup = True
+    catchup=True,
+    dagrun_timeout=timedelta(seconds=DAGRUN_TIMEOUT_IN_SECS)
 )
 
 transformation_secret = Secret(

--- a/ext/scheduler/airflow2/resources/base_dag.py
+++ b/ext/scheduler/airflow2/resources/base_dag.py
@@ -16,6 +16,7 @@ SENSOR_DEFAULT_POKE_INTERVAL_IN_SECS = int(Variable.get("sensor_poke_interval_in
 SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", default_var=15 * 60 * 60))
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
+DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
 
 default_args = {
     "params": {
@@ -41,7 +42,8 @@ dag = DAG(
     default_args=default_args,
     schedule_interval={{ if eq .Job.Schedule.Interval "" }}None{{- else -}} {{ .Job.Schedule.Interval | quote}}{{end}},
     sla_miss_callback=optimus_sla_miss_notify,
-    catchup = {{ if .Job.Behavior.CatchUp -}} True{{- else -}} False {{- end }}
+    catchup={{ if .Job.Behavior.CatchUp -}}True{{- else -}}False{{- end }},
+    dagrun_timeout=timedelta(seconds=DAGRUN_TIMEOUT_IN_SECS)
 )
 
 {{$baseTaskSchema := .Job.Task.Unit.Info -}}

--- a/ext/scheduler/airflow2/resources/expected_compiled_template.py
+++ b/ext/scheduler/airflow2/resources/expected_compiled_template.py
@@ -16,6 +16,7 @@ SENSOR_DEFAULT_POKE_INTERVAL_IN_SECS = int(Variable.get("sensor_poke_interval_in
 SENSOR_DEFAULT_TIMEOUT_IN_SECS = int(Variable.get("sensor_timeout_in_secs", default_var=15 * 60 * 60))
 DAG_RETRIES = int(Variable.get("dag_retries", default_var=3))
 DAG_RETRY_DELAY = int(Variable.get("dag_retry_delay_in_secs", default_var=5 * 60))
+DAGRUN_TIMEOUT_IN_SECS = int(Variable.get("dagrun_timeout_in_secs", default_var=3 * 24 * 60 * 60))
 
 default_args = {
     "params": {
@@ -41,7 +42,8 @@ dag = DAG(
     default_args=default_args,
     schedule_interval="* * * * *",
     sla_miss_callback=optimus_sla_miss_notify,
-    catchup = True
+    catchup=True,
+    dagrun_timeout=timedelta(seconds=DAGRUN_TIMEOUT_IN_SECS)
 )
 
 transformation_secret = Secret(


### PR DESCRIPTION
Add dagrun_timeout to prevent having unnecessary slot-consuming long-running dagruns.

The default value is set to 3 days, however, it can be set through this Airflow variable `dagrun_timeout_in_secs`.