### PR TITLE
fix: set CrossTenantDependancySensor mode from poke to reschedule

### DIFF
--- a/ext/scheduler/airflow2/resources/__lib.py
+++ b/ext/scheduler/airflow2/resources/__lib.py
@@ -325,7 +325,9 @@ class CrossTenantDependencySensor(BaseSensorOperator):
             upstream_optimus_project: str,
             upstream_optimus_job: str,
             window_size: str,
+            *args,
             **kwargs) -> None:
+        kwargs['mode'] = kwargs.get('mode', 'reschedule')
         super().__init__(**kwargs)
         self.optimus_project = upstream_optimus_project
         self.optimus_job = upstream_optimus_job


### PR DESCRIPTION
fix: set CrossTenantDependancySensor mode from default poke to reschedule

Issue Link: https://github.com/odpf/optimus/issues/144