### PR TITLE
fix: bug caused by inter-dependency miss-assigned map

### DIFF
--- a/job/dependency_resolver.go
+++ b/job/dependency_resolver.go
@@ -156,13 +156,16 @@ func (r *dependencyResolver) resolveStaticDependencies(ctx context.Context, jobS
 					}
 					projectName := depParts[0]
 					jobName := depParts[1]
-					job, proj, err := projectJobSpecRepo.GetByNameForProject(ctx, projectName, jobName)
-					if err != nil {
-						return models.JobSpec{}, errors.Wrapf(err, "%s for job %s", ErrUnknownCrossProjectDependency, depName)
+					if jobSpec.Dependencies[jobName].Job == nil {
+						job, proj, err := projectJobSpecRepo.GetByNameForProject(ctx, projectName, jobName)
+						if err != nil {
+							return models.JobSpec{}, errors.Wrapf(err, "%s for job %s", ErrUnknownCrossProjectDependency, depName)
+						}
+						depSpec.Job = &job
+						depSpec.Project = &proj
+						jobSpec.Dependencies[jobName] = depSpec
 					}
-					depSpec.Job = &job
-					depSpec.Project = &proj
-					jobSpec.Dependencies[depName] = depSpec
+					delete(jobSpec.Dependencies, depName)
 				}
 			default:
 				return models.JobSpec{}, errors.Errorf("unsupported dependency type: %s", depSpec.Type)

--- a/job/dependency_resolver_test.go
+++ b/job/dependency_resolver_test.go
@@ -979,7 +979,7 @@ func TestDependencyResolver(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec2, Project: &projectSpec, Type: models.JobSpecDependencyTypeIntra}, resolvedJobSpec1.Dependencies[jobSpec2.Name])
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpecExternal, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[jobSpecExternal.Name])
-			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[externalProjectName+"/"+jobSpec3.Name])
+			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[jobSpec3.Name])
 			assert.Equal(t, map[string]models.JobSpecDependency{}, resolvedJobSpec2.Dependencies)
 		})
 	})

--- a/job/dependency_resolver_test.go
+++ b/job/dependency_resolver_test.go
@@ -979,7 +979,7 @@ func TestDependencyResolver(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec2, Project: &projectSpec, Type: models.JobSpecDependencyTypeIntra}, resolvedJobSpec1.Dependencies[jobSpec2.Name])
 			assert.Equal(t, models.JobSpecDependency{Job: &jobSpecExternal, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[jobSpecExternal.Name])
-			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[jobSpec3.Name])
+			assert.Equal(t, models.JobSpecDependency{Job: &jobSpec3, Project: &externalProjectSpec, Type: models.JobSpecDependencyTypeInter}, resolvedJobSpec1.Dependencies[externalProjectName+"/"+jobSpec3.Name])
 			assert.Equal(t, map[string]models.JobSpecDependency{}, resolvedJobSpec2.Dependencies)
 		})
 	})


### PR DESCRIPTION
### Description

This PR is related to #137 , and further information is available in the issue.

### Changes

The following is the summary of changes done in this PR:

* update the map key from `depName` into its `jobName`
* prioritised the already found job as the dependency to minimise access to database
* remove unused key in the dependency
* update the unit test