### PR TITLE
fix: logging for job and resource deployment

### DIFF
--- a/api/handler/v1beta1/job_spec.go
+++ b/api/handler/v1beta1/job_spec.go
@@ -105,7 +105,7 @@ func (sv *JobSpecServiceServer) DeployJobSpecification(stream pb.JobSpecificatio
 		stream.Send(&pb.DeployJobSpecificationResponse{
 			Success: true,
 			Ack:     true,
-			Message: "success",
+			Message: fmt.Sprintf("jobs with namespace [%s] are deployed successfully", req.NamespaceName),
 		})
 	}
 	sv.l.Info("finished job deployment", "time", time.Since(startTime))

--- a/api/handler/v1beta1/resource.go
+++ b/api/handler/v1beta1/resource.go
@@ -167,7 +167,7 @@ func (sv *ResourceServiceServer) DeployResourceSpecification(stream pb.ResourceS
 		stream.Send(&pb.DeployResourceSpecificationResponse{
 			Success: true,
 			Ack:     true,
-			Message: "success",
+			Message: fmt.Sprintf("resources with namespace [%s] are deployed successfully", request.NamespaceName),
 		})
 	}
 	sv.l.Info("finished resource deployment in", "time", time.Since(startTime))

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -227,10 +227,8 @@ func deployAllJobs(deployTimeoutCtx context.Context,
 				if verbose {
 					l.Info(fmt.Sprintf("[%d/%d] %s successfully deployed", counter, totalSpecsCount, resp.GetJobName()))
 				}
-			} else {
-				if verbose {
-					l.Info(resp.Message)
-				}
+			} else if verbose {
+				l.Info(resp.Message)
 			}
 		}
 	}
@@ -345,10 +343,8 @@ func deployAllResources(deployTimeoutCtx context.Context,
 				if verbose {
 					l.Info(fmt.Sprintf("[%d/%d] %s successfully deployed", counter, totalSpecsCount, resp.GetResourceName()))
 				}
-			} else {
-				if verbose {
-					l.Info(resp.Message)
-				}
+			} else if verbose {
+				l.Info(resp.Message)
 			}
 		}
 	}


### PR DESCRIPTION
This PR addresses:

* bug when namespaces are not configured, meaning missing namespace when deployment
* missing logging on job and resource deployment from the Optimus client

Log Before this PR:

```zsh
> [namespac1] Deploying resources for bigquery
> [namespace2] Deploying resources for bigquery
> [namespace1] Deploying jobs
> [namespace2] Deploying jobs
```

Log After this PR:

```zsh
> Deploying bigquery resources for namespace [namespace1]
> Deploying bigquery resources for namespace [namespace2]
> Receiving responses:
[1/2] resource1 successfully deployed
resources with namespace [namespace1] are deployed successfully
[2/2] resource2 successfully deployed
resources with namespace [namespace2] are deployed successfully

> Deploying jobs for namespace [namespace1]
> Deploying jobs for namespace [namespace2]
> Receiving responses:
[1/3] job1 successfully deployed
[2/3] job2 successfully deployed
jobs with namespace [namespace1] are deployed successfully
[3/3] job3 successfully deployed
jobs with namespace [namespace12] are deployed successfully
```