### PR TITLE
feat: bind config with cobra flags to override the conf

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -23,7 +23,7 @@ func adminCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/admin_build_instance.go
+++ b/cmd/admin_build_instance.go
@@ -29,8 +29,6 @@ const unsubstitutedValue = "<no value>"
 
 func adminBuildInstanceCommand(conf *config.ClientConfig) *cli.Command {
 	var (
-		optimusHost    string
-		projectName    string
 		assetOutputDir = "/tmp/"
 		runType        = "task"
 		runName        string
@@ -54,12 +52,12 @@ func adminBuildInstanceCommand(conf *config.ClientConfig) *cli.Command {
 	cmd.Flags().StringVar(&runName, "name", "", "Name of running instance, e.g., bq2bq/transporter/predator")
 	cmd.MarkFlagRequired("name")
 
-	cmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Name of the optimus project") // TODO: fix overriding conf via args
-	cmd.Flags().StringVar(&optimusHost, "host", optimusHost, "Optimus service endpoint url")         // TODO: fix overriding conf via args
+	cmd.Flags().StringP("project-name", "p", defaultProjectName, "Name of the optimus project")
+	cmd.Flags().String("host", defaultHost, "Optimus service endpoint url")
 
 	cmd.RunE = func(c *cli.Command, args []string) error {
-		projectName = conf.Project.Name
-		optimusHost = conf.Host
+		projectName := conf.Project.Name
+		optimusHost := conf.Host
 		l := initClientLogger(conf.Log)
 		jobName := args[0]
 		l.Info(fmt.Sprintf("Requesting resources for project %s, job %s at %s", projectName, jobName, optimusHost))

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -35,7 +35,7 @@ func backupCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/backup_list.go
+++ b/cmd/backup_list.go
@@ -23,11 +23,10 @@ func backupListCommand(conf *config.ClientConfig) *cli.Command {
 			Short:   "Get list of backups per project and datastore",
 			Example: "optimus backup list",
 		}
-		project string
 	)
-	backupCmd.Flags().StringVarP(&project, "project", "p", project, "project name of optimus managed repository") // TODO: fix overriding conf via args
+	backupCmd.Flags().StringP("project-name", "p", defaultProjectName, "project name of optimus managed repository")
 	backupCmd.RunE = func(cmd *cli.Command, args []string) error {
-		project = conf.Project.Name
+		project := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		dsRepo := models.DatastoreRegistry
 		availableStorer := []string{}

--- a/cmd/backup_status.go
+++ b/cmd/backup_status.go
@@ -19,16 +19,15 @@ import (
 
 func backupStatusCommand(conf *config.ClientConfig) *cli.Command {
 	var (
-		project   string
 		backupCmd = &cli.Command{
 			Use:     "status",
 			Short:   "Get backup info using uuid and datastore",
 			Example: "optimus backup status <uuid>",
 		}
 	)
-	backupCmd.Flags().StringVarP(&project, "project", "p", project, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	backupCmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 	backupCmd.RunE = func(cmd *cli.Command, args []string) error {
-		project = conf.Project.Name
+		project := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		dsRepo := models.DatastoreRegistry
 		availableStorer := []string{}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -48,6 +48,11 @@ const (
 	BackoffDuration    = 100 * time.Millisecond
 )
 
+const (
+	defaultProjectName = "sample_project"
+	defaultHost        = "localhost:9100"
+)
+
 // JobSpecRepository represents a storage interface for Job specifications locally
 type JobSpecRepository interface {
 	SaveAt(models.JobSpec, string) error

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	defaultHost               = "localhost"
 	defaultFilePermissionMode = 0o655
 )
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,7 +29,7 @@ const (
 // deployCommand pushes current repo to optimus service
 func deployCommand() *cli.Command {
 	var (
-		namespaces      []string
+		namespaceNames  []string
 		ignoreJobs      bool
 		ignoreResources bool
 		verbose         bool
@@ -48,7 +48,7 @@ func deployCommand() *cli.Command {
 	}
 
 	cmd.Flags().StringVarP(&configFilePath, "config", "c", configFilePath, "File path for client configuration")
-	cmd.Flags().StringSliceVarP(&namespaces, "namespaces", "N", nil, "Selected namespaces of optimus project")
+	cmd.Flags().StringSliceVarP(&namespaceNames, "namespace-names", "N", nil, "Selected namespaces of optimus project")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print details related to deployment stages")
 	cmd.Flags().BoolVar(&ignoreJobs, "ignore-jobs", false, "Ignore deployment of jobs")
 	cmd.Flags().BoolVar(&ignoreResources, "ignore-resources", false, "Ignore deployment of resources")
@@ -75,11 +75,11 @@ func deployCommand() *cli.Command {
 		l.Info(fmt.Sprintf("Deploying project: %s to %s", conf.Project.Name, conf.Host))
 		start := time.Now()
 
-		if err := validateNamespaces(datastoreSpecFs, namespaces); err != nil {
+		if err := validateNamespaces(datastoreSpecFs, namespaceNames); err != nil {
 			return err
 		}
 
-		err = postDeploymentRequest(l, *conf, pluginRepo, dsRepo, datastoreSpecFs, namespaces, ignoreJobs, ignoreResources, verbose)
+		err = postDeploymentRequest(l, *conf, pluginRepo, dsRepo, datastoreSpecFs, namespaceNames, ignoreJobs, ignoreResources, verbose)
 		if err != nil {
 			return err
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -57,7 +57,7 @@ func deployCommand() *cli.Command {
 		pluginRepo := models.PluginRegistry
 		dsRepo := models.DatastoreRegistry
 		// TODO: find a way to load the config in one place
-		conf, err := config.LoadClientConfig(configFilePath)
+		conf, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -25,7 +25,7 @@ func jobCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/job_run_list.go
+++ b/cmd/job_run_list.go
@@ -26,17 +26,15 @@ func jobRunListCommand(conf *config.ClientConfig) *cli.Command {
 		Example: `optimus job runs <sample_job_goes_here> [--project \"project-id\"] [--start_date \"2006-01-02T15:04:05Z07:00\" --end_date \"2006-01-02T15:04:05Z07:00\"]`,
 		Args:    cli.MinimumNArgs(1),
 	}
-	var projectName string
-	var host string
 	var startDate string
 	var endDate string
-	cmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
-	cmd.Flags().StringVar(&host, "host", host, "Optimus service endpoint url")                                      // TODO: fix overriding conf via args
+	cmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
+	cmd.Flags().String("host", defaultHost, "Optimus service endpoint url")
 	cmd.Flags().StringVar(&startDate, "start_date", "", "start date of job run")
 	cmd.Flags().StringVar(&endDate, "end_date", "", "end date of job run")
 	cmd.RunE = func(c *cli.Command, args []string) error {
-		projectName = conf.Project.Name
-		host = conf.Host
+		projectName := conf.Project.Name
+		host := conf.Host
 		l := initClientLogger(conf.Log)
 		jobName := args[0]
 		l.Info(fmt.Sprintf("Requesting status for project %s, job %s from %s",

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -70,7 +70,7 @@ func replayCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/replay_create.go
+++ b/cmd/replay_create.go
@@ -26,7 +26,6 @@ func replayCreateCommand(conf *config.ClientConfig) *cli.Command {
 		ignoreDownstream = false
 		allDownstream    = false
 		skipConfirm      = false
-		projectName      string
 		namespaceName    string
 	)
 
@@ -50,7 +49,7 @@ Date ranges are inclusive.
 			return nil
 		},
 	}
-	reCmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	reCmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 	reCmd.Flags().StringVarP(&namespaceName, "namespace", "n", namespaceName, "Namespace of job that needs to be replayed")
 	reCmd.MarkFlagRequired("namespace")
 
@@ -61,7 +60,7 @@ Date ranges are inclusive.
 	reCmd.Flags().BoolVar(&allDownstream, "all-downstream", allDownstream, "Run replay for all downstream across namespaces")
 
 	reCmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		endDate := args[1]
 		if len(args) >= 3 { //nolint: gomnd

--- a/cmd/replay_list.go
+++ b/cmd/replay_list.go
@@ -17,8 +17,7 @@ import (
 
 func replayListCommand(conf *config.ClientConfig) *cli.Command {
 	var (
-		projectName string
-		reCmd       = &cli.Command{
+		reCmd = &cli.Command{
 			Use:     "list",
 			Short:   "Get list of a replay mapping to a project",
 			Example: "optimus replay list",
@@ -27,9 +26,9 @@ The list command is used to fetch the recent replay in one project.
 		`,
 		}
 	)
-	reCmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	reCmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 	reCmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		dialTimeoutCtx, dialCancel := context.WithTimeout(context.Background(), OptimusDialTimeout)
 		defer dialCancel()

--- a/cmd/replay_status.go
+++ b/cmd/replay_status.go
@@ -16,8 +16,6 @@ import (
 )
 
 func replayStatusCommand(conf *config.ClientConfig) *cli.Command {
-	var projectName string
-
 	reCmd := &cli.Command{
 		Use:     "status",
 		Short:   "Get status of a replay using its ID",
@@ -33,9 +31,9 @@ It takes one argument, replay ID[required] that gets generated when starting a r
 			return nil
 		},
 	}
-	reCmd.Flags().StringVarP(&projectName, "project", "p", projectName, "project name of optimus managed repository") // TODO: fix overriding conf via args
+	reCmd.Flags().StringP("project-name", "p", defaultProjectName, "project name of optimus managed repository")
 	reCmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		dialTimeoutCtx, dialCancel := context.WithTimeout(context.Background(), OptimusDialTimeout)
 		defer dialCancel()

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -39,7 +39,7 @@ func resourceCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -58,7 +58,6 @@ func secretCommand() *cli.Command {
 
 func secretSetSubCommand(conf *config.ClientConfig) *cli.Command {
 	var (
-		projectName   string
 		namespaceName string
 		filePath      string
 		encoded       bool
@@ -76,7 +75,7 @@ Secret value can be either provided in second argument or through file flag.
 Use base64 flag if the value has been encoded.
 		`,
 	}
-	secretCmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	secretCmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 	secretCmd.Flags().StringVarP(&namespaceName, "namespace", "n", namespaceName, "Namespace of deployee")
 	secretCmd.Flags().BoolVar(&encoded, "base64", false, "Create secret with value that has been encoded")
 	secretCmd.Flags().BoolVar(&updateOnly, "update-only", false, "Only update existing secret, do not create new")
@@ -84,7 +83,7 @@ Use base64 flag if the value has been encoded.
 	secretCmd.Flags().BoolVar(&skipConfirm, "confirm", false, "Skip asking for confirmation")
 
 	secretCmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		secretName, err := getSecretName(args)
 		if err != nil {
@@ -144,18 +143,16 @@ Use base64 flag if the value has been encoded.
 }
 
 func secretListSubCommand(conf *config.ClientConfig) *cli.Command {
-	var projectName string
-
 	secretListCmd := &cli.Command{
 		Use:     "list",
 		Short:   "Show all the secrets registered with optimus",
 		Example: "optimus secret list",
 		Long:    `This operation shows the secrets for project.`,
 	}
-	secretListCmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	secretListCmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 
 	secretListCmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		updateSecretRequest := &pb.ListSecretsRequest{
 			ProjectName: projectName,
@@ -166,7 +163,7 @@ func secretListSubCommand(conf *config.ClientConfig) *cli.Command {
 }
 
 func secretDeleteSubCommand(conf *config.ClientConfig) *cli.Command {
-	var projectName, namespaceName string
+	var namespaceName string
 
 	cmd := &cli.Command{
 		Use:     "delete",
@@ -174,11 +171,11 @@ func secretDeleteSubCommand(conf *config.ClientConfig) *cli.Command {
 		Example: "optimus secret delete <secret_name>",
 		Long:    `This operation deletes a secret registered with optimus.`,
 	}
-	cmd.Flags().StringVarP(&projectName, "project", "p", projectName, "Project name of optimus managed repository") // TODO: fix overriding conf via args
+	cmd.Flags().StringP("project-name", "p", defaultProjectName, "Project name of optimus managed repository")
 	cmd.Flags().StringVarP(&namespaceName, "namespace", "n", namespaceName, "Namespace name of optimus managed repository")
 
 	cmd.RunE = func(cmd *cli.Command, args []string) error {
-		projectName = conf.Project.Name
+		projectName := conf.Project.Name
 		l := initClientLogger(conf.Log)
 		secretName, err := getSecretName(args)
 		if err != nil {

--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -41,7 +41,7 @@ func secretCommand() *cli.Command {
 
 	cmd.PersistentPreRunE = func(cmd *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		c, err := config.LoadClientConfig(configFilePath)
+		c, err := config.LoadClientConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,11 +23,12 @@ func serveCommand() *cli.Command {
 		},
 	}
 
+	cmd.Flags().Int("serve.port", 0, "serve port override") // Example
 	cmd.Flags().StringVarP(&configFilePath, "config", "c", configFilePath, "File path for server configuration")
 
 	cmd.RunE = func(c *cli.Command, args []string) error {
 		// TODO: find a way to load the config in one place
-		conf, err := config.LoadServerConfig(configFilePath)
+		conf, err := config.LoadServerConfig(configFilePath, cmd.Flags())
 		if err != nil {
 			return err
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,7 +23,6 @@ func serveCommand() *cli.Command {
 		},
 	}
 
-	cmd.Flags().Int("serve.port", 0, "serve port override") // Example
 	cmd.Flags().StringVarP(&configFilePath, "config", "c", configFilePath, "File path for server configuration")
 
 	cmd.RunE = func(c *cli.Command, args []string) error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -49,7 +49,7 @@ func versionCommand() *cli.Command {
 		// Print server version
 		if isWithServer {
 			// TODO: find a way to load the config in one place
-			conf, err := config.LoadClientConfig(configFilePath)
+			conf, err := config.LoadClientConfig(configFilePath, c.Flags())
 			if err != nil {
 				return err
 			}

--- a/config/loader.go
+++ b/config/loader.go
@@ -44,7 +44,7 @@ func init() { // TODO: move paths initialization outside init()
 }
 
 // LoadClientConfig load the project specific config from these locations:
-// 1. flags. eg ./optimus <client_command> --project.name project1
+// 1. flags. eg ./optimus <client_command> --project-name project1
 // 2. filepath. ./optimus <client_command> -c "path/to/config/optimus.yaml"
 // 3. current dir. Optimus will look at current directory if there's optimus.yaml there, use it
 func LoadClientConfig(filePath string, flags *pflag.FlagSet) (*ClientConfig, error) {
@@ -89,7 +89,7 @@ func LoadClientConfig(filePath string, flags *pflag.FlagSet) (*ClientConfig, err
 }
 
 // LoadServerConfig load the server specific config from these locations:
-// 1. flags. eg ./optimus <server_command> --serve.port 8000
+// 1. flags. eg ./optimus <server_command> --serve-port 8000
 // 2. filepath. ./optimus <server_command> -c "path/to/config.yaml"
 // 3. env var. eg. OPTIMUS_SERVE_PORT, etc
 // 4. executable binary location

--- a/config/loader.go
+++ b/config/loader.go
@@ -55,6 +55,7 @@ func LoadClientConfig(filePath string, flags *pflag.FlagSet) (*ClientConfig, err
 	v.SetFs(FS)
 
 	// bind with flags
+	setPFlagsNormalizer(flags)
 	if err := v.BindPFlags(flags); err != nil {
 		return nil, err
 	}

--- a/config/loader.go
+++ b/config/loader.go
@@ -100,6 +100,7 @@ func LoadServerConfig(filePath string, flags *pflag.FlagSet) (*ServerConfig, err
 	v.SetFs(FS)
 
 	// bind with flags
+	setPFlagsNormalizer(flags)
 	if err := v.BindPFlags(flags); err != nil {
 		return nil, err
 	}
@@ -144,4 +145,14 @@ func validateFilepath(fs afero.Fs, fpath string) error {
 		return fmt.Errorf("%s not a file", fpath)
 	}
 	return nil
+}
+
+func setPFlagsNormalizer(flags *pflag.FlagSet) {
+	// normalize with the pflag names with replacer
+	normalizeFunc := flags.GetNormalizeFunc()
+	flags.SetNormalizeFunc(func(fs *pflag.FlagSet, name string) pflag.NormalizedName {
+		result := normalizeFunc(fs, name)
+		name = strings.ReplaceAll(string(result), "-", ".")
+		return pflag.NormalizedName(name)
+	})
 }

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -105,7 +105,7 @@ func (s *ConfigTestSuite) TestLoadClientConfig() {
 
 	s.Run("WhenFilepathIsEmpty", func() {
 		s.Run("WhenConfigInCurrentPathIsExist", func() {
-			conf, err := config.LoadClientConfig(config.EmptyPath)
+			conf, err := config.LoadClientConfig(config.EmptyPath, config.EmptyFlags)
 
 			s.Assert().NoError(err)
 			s.Assert().NotNil(conf)
@@ -116,7 +116,7 @@ func (s *ConfigTestSuite) TestLoadClientConfig() {
 			s.a.Remove(currFilePath)
 			defer s.a.WriteFile(currFilePath, []byte(clientConfig), fs.ModeTemporary)
 
-			conf, err := config.LoadClientConfig(config.EmptyPath)
+			conf, err := config.LoadClientConfig(config.EmptyPath, config.EmptyFlags)
 			s.Assert().Error(err)
 			s.Assert().Nil(conf)
 		})
@@ -134,7 +134,7 @@ func (s *ConfigTestSuite) TestLoadClientConfig() {
 			s.a.WriteFile(samplePath, []byte(b.String()), fs.ModeTemporary)
 			defer s.a.Fs.RemoveAll(samplePath)
 
-			conf, err := config.LoadClientConfig(samplePath)
+			conf, err := config.LoadClientConfig(samplePath, config.EmptyFlags)
 
 			s.Assert().NoError(err)
 			s.Assert().NotNil(conf)
@@ -142,7 +142,7 @@ func (s *ConfigTestSuite) TestLoadClientConfig() {
 		})
 
 		s.Run("WhenFilePathIsNotValid", func() {
-			conf, err := config.LoadClientConfig("/path/not/exist")
+			conf, err := config.LoadClientConfig("/path/not/exist", config.EmptyFlags)
 
 			s.Assert().Error(err)
 			s.Assert().Nil(conf)
@@ -157,7 +157,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 
 	s.Run("WhenFilepathIsEmpty", func() {
 		s.Run("WhenEnvExist", func() {
-			conf, err := config.LoadServerConfig(config.EmptyPath)
+			conf, err := config.LoadServerConfig(config.EmptyPath, config.EmptyFlags)
 
 			s.Assert().NoError(err)
 			s.Assert().NotNil(conf)
@@ -169,7 +169,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 			s.unsetServerConfigEnv()
 			defer s.initServerConfigEnv()
 
-			conf, err := config.LoadServerConfig(config.EmptyPath)
+			conf, err := config.LoadServerConfig(config.EmptyPath, config.EmptyFlags)
 
 			s.Assert().NoError(err)
 			s.Assert().NotNil(conf)
@@ -182,7 +182,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 			defer s.initServerConfigEnv()
 			defer s.a.WriteFile(execFilePath, []byte(serverConfig), fs.ModeTemporary)
 
-			conf, err := config.LoadServerConfig(config.EmptyPath)
+			conf, err := config.LoadServerConfig(config.EmptyPath, config.EmptyFlags)
 
 			s.Assert().Error(err)
 			s.Assert().Nil(conf)
@@ -194,7 +194,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 			samplePath := "./sample/path/config.yaml"
 			s.a.WriteFile(samplePath, []byte("version: 2"), os.ModeTemporary)
 
-			conf, err := config.LoadServerConfig(samplePath)
+			conf, err := config.LoadServerConfig(samplePath, config.EmptyFlags)
 
 			s.Assert().NoError(err)
 			s.Assert().NotNil(conf)
@@ -204,7 +204,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 
 		s.Run("WhenFilePathIsNotValid", func() {
 			s.a.MkdirAll("/path/dir/", os.ModeTemporary)
-			conf, err := config.LoadServerConfig("/path/dir/")
+			conf, err := config.LoadServerConfig("/path/dir/", config.EmptyFlags)
 			s.Assert().Error(err)
 			s.Assert().Nil(conf)
 		})


### PR DESCRIPTION
- [x] overriding the config via flags provided by cobra
- [x] mapping the flag with `-` delimiter instead of `.` delimiter (--project-name instead of --project.name)
- [x] change flag names for each command that needs config overriding

TODO next (can be done in separate PR):
- [ ] bump salt version to support pflags
- [ ] rename `--project` to `--project-name` on entrypoint.sh for each plugins