### PR TITLE
fix: pass namespace spec that has secrets to DeployJobs process

### DIFF
--- a/cmd/server/optimus.go
+++ b/cmd/server/optimus.go
@@ -276,7 +276,7 @@ func (s *OptimusServer) setupHandlers() error {
 		),
 	})
 
-	deployer := job.NewDeployer(dependencyResolver, priorityResolver, scheduler)
+	deployer := job.NewDeployer(dependencyResolver, priorityResolver, scheduler, namespaceService)
 
 	engine := jobRunCompiler.NewGoEngine()
 	// runtime service instance over grpc

--- a/job/deployer_test.go
+++ b/job/deployer_test.go
@@ -73,6 +73,9 @@ func TestDeployer(t *testing.T) {
 			batchScheduler := new(mock.Scheduler)
 			defer batchScheduler.AssertExpectations(t)
 
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
+
 			jobID1 := uuid.New()
 			jobID2 := uuid.New()
 
@@ -212,10 +215,13 @@ func TestDeployer(t *testing.T) {
 
 			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return(jobSpecsAfterPriorityResolution, nil)
 
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec1.Name).Return(namespaceSpec1, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec1, []models.JobSpec{jobSpecsAfterPriorityResolution[0]}, nil).Return(nil).Once()
+
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec2.Name).Return(namespaceSpec2, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec2, []models.JobSpec{jobSpecsAfterPriorityResolution[1]}, nil).Return(nil).Once()
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Nil(t, err)
@@ -235,6 +241,9 @@ func TestDeployer(t *testing.T) {
 
 			batchScheduler := new(mock.Scheduler)
 			defer batchScheduler.AssertExpectations(t)
+
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
 
 			jobID1 := uuid.New()
 			jobID2 := uuid.New()
@@ -411,10 +420,13 @@ func TestDeployer(t *testing.T) {
 
 			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return(jobSpecsAfterPriorityResolution, nil)
 
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec1.Name).Return(namespaceSpec1, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec1, []models.JobSpec{jobSpecsAfterPriorityResolution[0]}, nil).Return(nil).Once()
+
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec2.Name).Return(namespaceSpec2, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec2, []models.JobSpec{jobSpecsAfterPriorityResolution[1]}, nil).Return(nil).Once()
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Nil(t, err)
@@ -434,6 +446,9 @@ func TestDeployer(t *testing.T) {
 
 			hookUnit2 := new(mock.BasePlugin)
 			defer hookUnit2.AssertExpectations(t)
+
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
 
 			jobID1 := uuid.New()
 			jobID2 := uuid.New()
@@ -612,10 +627,13 @@ func TestDeployer(t *testing.T) {
 
 			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return(jobSpecsAfterPriorityResolution, nil)
 
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec1.Name).Return(namespaceSpec1, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec1, []models.JobSpec{jobSpecsAfterPriorityResolution[0]}, nil).Return(nil).Once()
+
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec2.Name).Return(namespaceSpec2, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec2, []models.JobSpec{jobSpecsAfterPriorityResolution[1]}, nil).Return(nil).Once()
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Nil(t, err)
@@ -630,9 +648,12 @@ func TestDeployer(t *testing.T) {
 			batchScheduler := new(mock.Scheduler)
 			defer batchScheduler.AssertExpectations(t)
 
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
+
 			dependencyResolver.On("FetchJobSpecsWithJobDependencies", ctx, projectSpec, nil).Return([]models.JobSpec{}, errors.New(errorMsg))
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Equal(t, errorMsg, err.Error())
@@ -647,6 +668,9 @@ func TestDeployer(t *testing.T) {
 
 			batchScheduler := new(mock.Scheduler)
 			defer batchScheduler.AssertExpectations(t)
+
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
 
 			jobID1 := uuid.New()
 			jobID2 := uuid.New()
@@ -750,12 +774,12 @@ func TestDeployer(t *testing.T) {
 
 			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return([]models.JobSpec{}, errors.New(errorMsg))
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Equal(t, errorMsg, err.Error())
 		})
-		t.Run("should fail when unable to deploy jobs", func(t *testing.T) {
+		t.Run("should fail when unable to get namespace spec", func(t *testing.T) {
 			dependencyResolver := new(mock.DependencyResolver)
 			defer dependencyResolver.AssertExpectations(t)
 
@@ -764,6 +788,9 @@ func TestDeployer(t *testing.T) {
 
 			batchScheduler := new(mock.Scheduler)
 			defer batchScheduler.AssertExpectations(t)
+
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
 
 			jobID1 := uuid.New()
 			jobID2 := uuid.New()
@@ -904,11 +931,175 @@ func TestDeployer(t *testing.T) {
 
 			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return(jobSpecsAfterPriorityResolution, nil)
 
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec1.Name).Return(namespaceSpec1, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec1, []models.JobSpec{jobSpecsAfterPriorityResolution[0]}, nil).Return(nil)
 			deployError := errors.New(errorMsg)
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec2.Name).Return(models.NamespaceSpec{}, deployError).Once()
+
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
+			err := deployer.Deploy(ctx, projectSpec, nil)
+
+			assert.Equal(t, &multierror.Error{Errors: []error{deployError}}, err)
+		})
+		t.Run("should fail when unable to deploy jobs", func(t *testing.T) {
+			dependencyResolver := new(mock.DependencyResolver)
+			defer dependencyResolver.AssertExpectations(t)
+
+			priorityResolver := new(mock.PriorityResolver)
+			defer priorityResolver.AssertExpectations(t)
+
+			batchScheduler := new(mock.Scheduler)
+			defer batchScheduler.AssertExpectations(t)
+
+			namespaceService := new(mock.NamespaceService)
+			defer namespaceService.AssertExpectations(t)
+
+			jobID1 := uuid.New()
+			jobID2 := uuid.New()
+
+			jobSpecsBase := []models.JobSpec{
+				{
+					Version: 1,
+					ID:      jobID1,
+					Name:    "test",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task:          models.JobSpecTask{},
+					NamespaceSpec: namespaceSpec1,
+				},
+				{
+					Version: 1,
+					ID:      jobID2,
+					Name:    "test-2",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task:          models.JobSpecTask{},
+					NamespaceSpec: namespaceSpec2,
+				},
+			}
+			jobSpecsAfterJobDependencyEnrich := []models.JobSpec{
+				{
+					Version: 1,
+					ID:      jobID1,
+					Name:    "test",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task: models.JobSpecTask{},
+					Dependencies: map[string]models.JobSpecDependency{
+						jobSpecsBase[1].Name: {
+							Project: &projectSpec,
+							Job:     &jobSpecsBase[1],
+							Type:    models.JobSpecDependencyTypeIntra,
+						},
+					},
+					NamespaceSpec: namespaceSpec1,
+				},
+				{
+					Version: 1,
+					ID:      jobID2,
+					Name:    "test-2",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task:          models.JobSpecTask{},
+					NamespaceSpec: namespaceSpec2,
+				},
+			}
+			jobSpecsAfterHookDependencyEnrich := []models.JobSpec{
+				{
+					Version: 1,
+					ID:      jobID1,
+					Name:    "test",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task: models.JobSpecTask{},
+					Dependencies: map[string]models.JobSpecDependency{
+						jobSpecsBase[1].Name: {
+							Project: &projectSpec,
+							Job:     &jobSpecsBase[1],
+							Type:    models.JobSpecDependencyTypeIntra,
+						},
+					},
+					NamespaceSpec: namespaceSpec1,
+				},
+				{
+					Version: 1,
+					ID:      jobID2,
+					Name:    "test-2",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task:          models.JobSpecTask{},
+					NamespaceSpec: namespaceSpec2,
+				},
+			}
+			jobSpecsAfterPriorityResolution := []models.JobSpec{
+				{
+					Version: 1,
+					ID:      jobID1,
+					Name:    "test",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task: models.JobSpecTask{
+						Priority: 10000,
+					},
+					Dependencies: map[string]models.JobSpecDependency{
+						jobSpecsBase[1].Name: {
+							Project: &projectSpec,
+							Job:     &jobSpecsBase[1],
+							Type:    models.JobSpecDependencyTypeIntra,
+						},
+					},
+					NamespaceSpec: namespaceSpec1,
+				},
+				{
+					Version: 1,
+					ID:      jobID2,
+					Name:    "test-2",
+					Owner:   "optimus",
+					Schedule: models.JobSpecSchedule{
+						StartDate: time.Date(2020, 12, 2, 0, 0, 0, 0, time.UTC),
+						Interval:  "@daily",
+					},
+					Task: models.JobSpecTask{
+						Priority: 9000,
+					},
+					NamespaceSpec: namespaceSpec2,
+				},
+			}
+
+			dependencyResolver.On("FetchJobSpecsWithJobDependencies", ctx, projectSpec, nil).Return(jobSpecsAfterJobDependencyEnrich, nil)
+			dependencyResolver.On("FetchHookWithDependencies", jobSpecsAfterJobDependencyEnrich[0]).Return([]models.JobSpecHook{}).Once()
+			dependencyResolver.On("FetchHookWithDependencies", jobSpecsAfterJobDependencyEnrich[1]).Return([]models.JobSpecHook{}).Once()
+
+			priorityResolver.On("Resolve", ctx, jobSpecsAfterHookDependencyEnrich, nil).Return(jobSpecsAfterPriorityResolution, nil)
+
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec1.Name).Return(namespaceSpec1, nil).Once()
+			batchScheduler.On("DeployJobs", ctx, namespaceSpec1, []models.JobSpec{jobSpecsAfterPriorityResolution[0]}, nil).Return(nil)
+			deployError := errors.New(errorMsg)
+			namespaceService.On("Get", ctx, projectSpec.Name, namespaceSpec2.Name).Return(namespaceSpec2, nil).Once()
 			batchScheduler.On("DeployJobs", ctx, namespaceSpec2, []models.JobSpec{jobSpecsAfterPriorityResolution[1]}, nil).Return(deployError)
 
-			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler)
+			deployer := job.NewDeployer(dependencyResolver, priorityResolver, batchScheduler, namespaceService)
 			err := deployer.Deploy(ctx, projectSpec, nil)
 
 			assert.Equal(t, &multierror.Error{Errors: []error{deployError}}, err)

--- a/models/job.go
+++ b/models/job.go
@@ -88,10 +88,10 @@ func (js JobSpec) GetProjectSpec() ProjectSpec {
 
 type JobSpecs []JobSpec
 
-func (js JobSpecs) GroupJobsPerNamespace() map[uuid.UUID][]JobSpec {
-	jobsGroup := make(map[uuid.UUID][]JobSpec)
+func (js JobSpecs) GroupJobsPerNamespace() map[string][]JobSpec {
+	jobsGroup := make(map[string][]JobSpec)
 	for _, jobSpec := range js {
-		jobsGroup[jobSpec.NamespaceSpec.ID] = append(jobsGroup[jobSpec.NamespaceSpec.ID], jobSpec)
+		jobsGroup[jobSpec.NamespaceSpec.Name] = append(jobsGroup[jobSpec.NamespaceSpec.Name], jobSpec)
 	}
 	return jobsGroup
 }

--- a/models/job_test.go
+++ b/models/job_test.go
@@ -249,4 +249,46 @@ func TestJob(t *testing.T) {
 			assert.Equal(t, expectedMap, actual)
 		})
 	})
+	t.Run("GroupJobsPerNamespace", func(t *testing.T) {
+		t.Run("should able to get map of namespace name and the jobs", func(t *testing.T) {
+			projectSpec := models.ProjectSpec{
+				ID:   models.ProjectID(uuid.New()),
+				Name: "sample-project",
+				Config: map[string]string{
+					"bucket": "gs://sample_directory",
+				},
+			}
+			namespaceSpec := models.NamespaceSpec{
+				ID:          uuid.New(),
+				Name:        "sample-namespace",
+				ProjectSpec: projectSpec,
+			}
+			namespaceSpec1 := models.NamespaceSpec{
+				ID:          uuid.New(),
+				Name:        "sample-namespace-2",
+				ProjectSpec: projectSpec,
+			}
+			jobSpec1 := models.JobSpec{
+				ID:            uuid.New(),
+				NamespaceSpec: namespaceSpec,
+			}
+			jobSpec2 := models.JobSpec{
+				ID:            uuid.New(),
+				NamespaceSpec: namespaceSpec1,
+			}
+			jobSpec3 := models.JobSpec{
+				ID:            uuid.New(),
+				NamespaceSpec: namespaceSpec1,
+			}
+			jobSpecs := models.JobSpecs{jobSpec1, jobSpec2, jobSpec3}
+			expected := map[string][]models.JobSpec{
+				namespaceSpec.Name:  {jobSpec1},
+				namespaceSpec1.Name: {jobSpec2, jobSpec3},
+			}
+
+			actual := jobSpecs.GroupJobsPerNamespace()
+
+			assert.Equal(t, expected, actual)
+		})
+	})
 }


### PR DESCRIPTION
Currently, when doing deploy jobs from the Refresh command, the deployment will fail due to the secrets are not found. This is caused by the NamespaceSpec that being passed to the DeployJobs process does not have secrets. 

The workaround is, that instead of NamespaceSpec that being passed is from one of the JobSpec, it will be re-fetched from NamespaceService, which will also include the secrets. This is preferable instead of preloading the secrets 1 by 1 when getting all the jobs.