### PR TITLE
fix: use correct script to drop job_dependency on migration down

### DIFF
--- a/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
+++ b/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
@@ -1,4 +1,1 @@
 DROP TABLE IF EXISTS job_dependency;
-
-DROP INDEX IF EXISTS job_dependency_job_id_idx;
-DROP INDEX IF EXISTS job_dependency_project_id_idx;

--- a/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
+++ b/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE job DROP IF EXISTS job_dependency;
+DROP TABLE IF EXISTS job_dependency;

--- a/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
+++ b/store/postgres/migrations/000020_add_job_dependencies_table.down.sql
@@ -1,1 +1,4 @@
 DROP TABLE IF EXISTS job_dependency;
+
+DROP INDEX IF EXISTS job_dependency_job_id_idx;
+DROP INDEX IF EXISTS job_dependency_project_id_idx;


### PR DESCRIPTION
Migration 000020 down was wrongly set. It should drop the `job_dependency` table, not drop `job_dependency` field in the `job` table.

Note: `job_dependency` in `job` is not exist.