### PR TITLE
fix: make catchup false by default

### DIFF
--- a/cmd/job_create.go
+++ b/cmd/job_create.go
@@ -252,7 +252,7 @@ this effects runtime dependencies and template macros`,
 		},
 		Asset: map[string]string{},
 		Behavior: local.JobBehavior{
-			Catchup:       true,
+			Catchup:       false,
 			DependsOnPast: false,
 		},
 		Dependencies: []local.JobDependency{},


### PR DESCRIPTION
making catchup true by default can have an impact on already scheduled jobs so it should be avoided, users need to be conscious before enabling this.