### PR TITLE
fix: change catchup default value from true to false

### DIFF
--- a/cmd/job_create.go
+++ b/cmd/job_create.go
@@ -252,7 +252,7 @@ this effects runtime dependencies and template macros`,
 		},
 		Asset: map[string]string{},
 		Behavior: local.JobBehavior{
-			Catchup:       true,
+			Catchup:       false,
 			DependsOnPast: false,
 		},
 		Dependencies: []local.JobDependency{},

--- a/compiler/job_run_input_compiler_test.go
+++ b/compiler/job_run_input_compiler_test.go
@@ -39,7 +39,7 @@ func TestJobRunInputCompiler(t *testing.T) {
 	plugin := &models.Plugin{Base: execUnit, CLIMod: cliMod}
 
 	behavior := models.JobSpecBehavior{
-		CatchUp:       true,
+		CatchUp:       false,
 		DependsOnPast: false,
 	}
 


### PR DESCRIPTION
Currently, the catch-up configuration in the job spec is set to `true`. This can be consuming lots of scheduler slots and resources as it will try to run the job from the start date to the current date. The default should be `false`.