### PR TITLE
fix: fix index on namespace table

### DIFF
--- a/store/postgres/migrations/000021_update_index_on_namespace_table.down.sql
+++ b/store/postgres/migrations/000021_update_index_on_namespace_table.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS namespace_name_idx;
+CREATE INDEX IF NOT EXISTS namespace_name_idx ON job (name);
+
+DROP INDEX IF EXISTS namespace_project_id_idx;
+CREATE INDEX IF NOT EXISTS namespace_project_id_idx ON job (project_id);

--- a/store/postgres/migrations/000021_update_index_on_namespace_table.up.sql
+++ b/store/postgres/migrations/000021_update_index_on_namespace_table.up.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS namespace_name_idx;
+CREATE INDEX IF NOT EXISTS namespace_name_idx ON namespace (name);
+
+DROP INDEX IF EXISTS namespace_project_id_idx;
+CREATE INDEX IF NOT EXISTS namespace_project_id_idx ON namespace (project_id);


### PR DESCRIPTION
The current version adds index on job table and not namespace: https://github.com/odpf/optimus/blob/main/store/postgres/migrations/000008_add_namespace.up.sql#L13