### PR TITLE
fix: bug when deleting secret

### DIFF
--- a/store/postgres/secret_repository.go
+++ b/store/postgres/secret_repository.go
@@ -226,9 +226,9 @@ func (repo *secretRepository) Delete(ctx context.Context, project models.Project
 
 	var result *gorm.DB
 	if namespace.Name == "" {
-		result = query.Where("namespace_id is null").Delete(&Secret{})
+		result = query.Where("namespace_id is null").Unscoped().Delete(&Secret{})
 	} else {
-		result = query.Where("namespace_id = ?", namespace.ID).Delete(&Secret{})
+		result = query.Where("namespace_id = ?", namespace.ID).Unscoped().Delete(&Secret{})
 	}
 
 	if result.Error != nil {

--- a/store/postgres/secret_repository.go
+++ b/store/postgres/secret_repository.go
@@ -220,15 +220,15 @@ func (repo secretRepository) GetSecrets(ctx context.Context, project models.Proj
 }
 
 func (repo *secretRepository) Delete(ctx context.Context, project models.ProjectSpec, namespace models.NamespaceSpec, secretName string) error {
-	query := repo.db.WithContext(ctx).
+	query := repo.db.Unscoped().WithContext(ctx).
 		Where("project_id = ?", project.ID.UUID()).
 		Where("name = ?", secretName)
 
 	var result *gorm.DB
 	if namespace.Name == "" {
-		result = query.Where("namespace_id is null").Unscoped().Delete(&Secret{})
+		result = query.Where("namespace_id is null").Delete(&Secret{})
 	} else {
-		result = query.Where("namespace_id = ?", namespace.ID).Unscoped().Delete(&Secret{})
+		result = query.Where("namespace_id = ?", namespace.ID).Delete(&Secret{})
 	}
 
 	if result.Error != nil {


### PR DESCRIPTION
This PR is to address a bug when we want to set a secret, where previously it's already deleted. Steps taken to encounter this error:

1. set secret with command `secret set [name] ...`
2. delete the secret with command `secret delete [name]`
3. re-run step 1. above and error should be encountered

The changes in this PR is to just add `Unscoped()` call function (reference)[https://gorm.io/docs/delete.html#Delete-permanently] during deletion to make Optimus delete it permanently.