### PR TITLE
fix: resolve bug when refreshing jobs with cross project dependency

### DIFF
--- a/store/postgres/job_dependency_repository.go
+++ b/store/postgres/job_dependency_repository.go
@@ -61,7 +61,7 @@ func (repo *jobDependencyRepository) Save(ctx context.Context, projectID models.
 
 func (repo *jobDependencyRepository) GetAll(ctx context.Context, projectID models.ProjectID) ([]models.JobIDDependenciesPair, error) {
 	var jobDependencies []JobDependency
-	if err := repo.db.WithContext(ctx).Preload("Project").Where("project_id = ?", projectID.UUID()).Find(&jobDependencies).Error; err != nil {
+	if err := repo.db.WithContext(ctx).Preload("DependentProject").Where("project_id = ?", projectID.UUID()).Find(&jobDependencies).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixing a compilation [issue](https://github.com/odpf/optimus/issues/348) on Job Refresh. This is caused by the dependency project is not properly loaded, causing the job spec of dependency jobs are not properly loaded.