### PR TITLE
fix: server crash when accepting improper resource create request

### DIFF
--- a/api/handler/v1beta1/adapter.go
+++ b/api/handler/v1beta1/adapter.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -442,6 +443,16 @@ func ToResourceProto(spec models.ResourceSpec) (*pb.ResourceSpecification, error
 }
 
 func FromResourceProto(spec *pb.ResourceSpecification, storeName string, datastoreRepo models.DatastoreRepo) (models.ResourceSpec, error) {
+	if spec == nil {
+		return models.ResourceSpec{}, errors.New("spec is nil")
+	}
+	if storeName == "" {
+		return models.ResourceSpec{}, errors.New("store name is empty")
+	}
+	if datastoreRepo == nil {
+		return models.ResourceSpec{}, errors.New("datastore repo is nil")
+	}
+
 	storer, err := datastoreRepo.GetByName(storeName)
 	if err != nil {
 		return models.ResourceSpec{}, err
@@ -449,7 +460,7 @@ func FromResourceProto(spec *pb.ResourceSpecification, storeName string, datasto
 
 	typeController, ok := storer.Types()[models.ResourceType(spec.GetType())]
 	if !ok {
-		return models.ResourceSpec{}, fmt.Errorf("unsupported type %s for datastore %s", spec.Type, storeName)
+		return models.ResourceSpec{}, fmt.Errorf("unsupported type [%s] for datastore [%s]", spec.Type, storeName)
 	}
 	buf, err := proto.Marshal(spec)
 	if err != nil {

--- a/mock/datastore.go
+++ b/mock/datastore.go
@@ -127,8 +127,23 @@ type SupportedDatastoreRepo struct {
 }
 
 func (repo *SupportedDatastoreRepo) GetByName(name string) (models.Datastorer, error) {
-	args := repo.Called(name)
-	return args.Get(0).(models.Datastorer), args.Error(1)
+	ret := repo.Called(name)
+
+	var r0 models.Datastorer
+	if rf, ok := ret.Get(0).(func(string) models.Datastorer); ok {
+		r0 = rf(name)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).(models.Datastorer)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else if ret.Get(1) != nil {
+		r1 = ret.Get(1).(error)
+	}
+
+	return r0, r1
 }
 
 func (repo *SupportedDatastoreRepo) GetAll() []models.Datastorer {


### PR DESCRIPTION
This PR is to address #352 . Even though the issue only mentioned about resource creation, but this solution should also address the same for updating resource. This is because the update process is similar to the creation.

### Changes

The followings are the changes done:

* update adapter to add further validation
* create the unit test to address such implementation
* update mock implementation to address the requirement

### Improvement

Based on this PR, there are some TODO that can be addressed through **separate cards**, as the changes might be bigger.

* add validation on the adapter initialization
* add more unit test on the adapter to address more cases
* update mock implementation to address two points above
* finding out the similar case where the server could crash based on the request from the user