### PR TITLE
fix: exclude health endpoint from tracing

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -146,9 +146,9 @@ func prepareHTTPProxy(grpcAddr string, grpcServer *grpc.Server) (*http.Server, f
 
 	// base router
 	baseMux := http.NewServeMux()
-	baseMux.HandleFunc("/ping", otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	baseMux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "pong")
-	}), "Ping").ServeHTTP)
+	})
 	baseMux.Handle("/api/", otelhttp.NewHandler(http.StripPrefix("/api", gwmux), "api"))
 
 	//nolint: gomnd


### PR DESCRIPTION
The health endpoint has tracing enabled, which creates a lot of traces and makes it difficult to find relevant traces.