### PR TITLE
fix: load server config from env var

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,7 +115,7 @@ func LoadServerConfig(filePath string) (*ServerConfig, error) {
 
 	// load the config
 	l := config.NewLoader(opts...)
-	if err := l.Load(cfg); err != nil {
+	if err := l.Load(cfg); err != nil && !errors.As(err, &config.ConfigFileNotFoundError{}) {
 		return nil, err
 	}
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -162,6 +162,8 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 
 	s.Run("WhenFilepathIsEmpty", func() {
 		s.Run("WhenEnvExist", func() {
+			s.a.Remove(execFilePath)
+			defer s.a.WriteFile(execFilePath, []byte(serverConfig), fs.ModeTemporary)
 			conf, err := config.LoadServerConfig(config.EmptyPath)
 
 			s.Assert().NoError(err)
@@ -188,9 +190,8 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 			defer s.a.WriteFile(execFilePath, []byte(serverConfig), fs.ModeTemporary)
 
 			conf, err := config.LoadServerConfig(config.EmptyPath)
-			s.Assert().NotNil(err)
-			s.Assert().ErrorAs(err, &saltConfig.ConfigFileNotFoundError{})
-			s.Assert().Nil(conf)
+			s.Assert().Nil(err)
+			s.Assert().NotNil(conf)
 		})
 	})
 
@@ -210,7 +211,7 @@ func (s *ConfigTestSuite) TestLoadServerConfig() {
 		s.Run("WhenFilePathIsNotValid", func() {
 			s.a.MkdirAll("/path/dir/", os.ModeTemporary)
 			conf, err := config.LoadServerConfig("/path/dir/")
-			s.Assert().NotNil(err)
+			s.Assert().Error(err)
 			s.Assert().Nil(conf)
 		})
 	})


### PR DESCRIPTION
Latest version of salt returns error when config file is not exist, meanwhile, in optimus, when config file is not exist, optimus can load the config via env var