### PR TITLE
fix: temp convert resource managers from array to single value

### DIFF
--- a/config/config_server.go
+++ b/config/config_server.go
@@ -5,12 +5,12 @@ import (
 )
 
 type ServerConfig struct {
-	Version          Version           `mapstructure:"version"`
-	Log              LogConfig         `mapstructure:"log"`
-	Serve            Serve             `mapstructure:"serve"`
-	Scheduler        SchedulerConfig   `mapstructure:"scheduler"`
-	Telemetry        TelemetryConfig   `mapstructure:"telemetry"`
-	ResourceManagers []ResourceManager `mapstructure:"resource_managers"`
+	Version          Version         `mapstructure:"version"`
+	Log              LogConfig       `mapstructure:"log"`
+	Serve            Serve           `mapstructure:"serve"`
+	Scheduler        SchedulerConfig `mapstructure:"scheduler"`
+	Telemetry        TelemetryConfig `mapstructure:"telemetry"`
+	ResourceManagers ResourceManager `mapstructure:"resource_managers"`
 }
 
 type Serve struct {
@@ -56,10 +56,10 @@ type TelemetryConfig struct {
 }
 
 type ResourceManager struct {
-	Name        string      `mapstructure:"name"`
-	Type        string      `mapstructure:"type"`
-	Description string      `mapstructure:"description"`
-	Config      interface{} `mapstructure:"config"`
+	Name        string                       `mapstructure:"name"`
+	Type        string                       `mapstructure:"type"`
+	Description string                       `mapstructure:"description"`
+	Config      ResourceManagerConfigOptimus `mapstructure:"config"`
 }
 
 type ResourceManagerConfigOptimus struct {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -63,7 +63,7 @@ telemetry:
   profile_addr: ":9110"
   jaeger_addr: "http://localhost:14268/api/traces"
 resource_managers:
-- name: external_optimus
+  name: external_optimus
   type: optimus
   description: neighbor optimus
   config:
@@ -281,15 +281,11 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 	s.expectedServerConfig.Telemetry.ProfileAddr = ":9110"
 	s.expectedServerConfig.Telemetry.JaegerAddr = "http://localhost:14268/api/traces"
 
-	s.expectedServerConfig.ResourceManagers = []config.ResourceManager{
-		{
-			Name:        "external_optimus",
-			Type:        "optimus",
-			Description: "neighbor optimus",
-			Config: map[interface{}]interface{}{
-				"host": "external.optimus.io",
-			},
-		},
+	s.expectedServerConfig.ResourceManagers = config.ResourceManager{
+		Name:        "external_optimus",
+		Type:        "optimus",
+		Description: "neighbor optimus",
+		Config: config.ResourceManagerConfigOptimus{Host: "external.optimus.io"},
 	}
 }
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -285,7 +285,7 @@ func (s *ConfigTestSuite) initExpectedServerConfig() {
 		Name:        "external_optimus",
 		Type:        "optimus",
 		Description: "neighbor optimus",
-		Config: config.ResourceManagerConfigOptimus{Host: "external.optimus.io"},
+		Config:      config.ResourceManagerConfigOptimus{Host: "external.optimus.io"},
 	}
 }
 

--- a/job/external_dependency_resolver.go
+++ b/job/external_dependency_resolver.go
@@ -22,7 +22,7 @@ type externalDependencyResolver struct {
 // NewExternalDependencyResolver creates a new instance of externalDependencyResolver
 func NewExternalDependencyResolver(conf config.ResourceManager) (ExternalDependencyResolver, error) {
 	var optimusResourceManagers []resourcemgr.ResourceManager
-	//for _, conf := range resourceManagerConfigs {
+	// for _, conf := range resourceManagerConfigs {
 	switch conf.Type {
 	case "optimus":
 		getter, err := resourcemgr.NewOptimusResourceManager(conf)

--- a/job/external_dependency_resolver.go
+++ b/job/external_dependency_resolver.go
@@ -20,20 +20,20 @@ type externalDependencyResolver struct {
 }
 
 // NewExternalDependencyResolver creates a new instance of externalDependencyResolver
-func NewExternalDependencyResolver(resourceManagerConfigs []config.ResourceManager) (ExternalDependencyResolver, error) {
+func NewExternalDependencyResolver(conf config.ResourceManager) (ExternalDependencyResolver, error) {
 	var optimusResourceManagers []resourcemgr.ResourceManager
-	for _, conf := range resourceManagerConfigs {
-		switch conf.Type {
-		case "optimus":
-			getter, err := resourcemgr.NewOptimusResourceManager(conf)
-			if err != nil {
-				return nil, err
-			}
-			optimusResourceManagers = append(optimusResourceManagers, getter)
-		default:
-			return nil, fmt.Errorf("resource manager [%s] is not recognized", conf.Type)
+	//for _, conf := range resourceManagerConfigs {
+	switch conf.Type {
+	case "optimus":
+		getter, err := resourcemgr.NewOptimusResourceManager(conf)
+		if err != nil {
+			return nil, err
 		}
+		optimusResourceManagers = append(optimusResourceManagers, getter)
+	default:
+		return nil, fmt.Errorf("resource manager [%s] is not recognized", conf.Type)
 	}
+	//}
 	return &externalDependencyResolver{
 		optimusResourceManagers: optimusResourceManagers,
 	}, nil


### PR DESCRIPTION
This is temprory arrangement to be able to specify resource manager config as environment variable.