### PR TITLE
fix: `job_end_event` trigger set to  `all_success`

### DIFF
--- a/ext/scheduler/airflow2/resources/base_dag.py
+++ b/ext/scheduler/airflow2/resources/base_dag.py
@@ -81,7 +81,7 @@ publish_job_end_event = PythonOperator(
         task_id = JOB_END_EVENT_NAME,
         python_callable = log_job_end,
         provide_context=True,
-        trigger_rule= 'all_done',
+        trigger_rule= 'all_success',
         dag=dag
     )
 

--- a/ext/scheduler/airflow2/resources/expected_compiled_template.py
+++ b/ext/scheduler/airflow2/resources/expected_compiled_template.py
@@ -73,7 +73,7 @@ publish_job_end_event = PythonOperator(
         task_id = JOB_END_EVENT_NAME,
         python_callable = log_job_end,
         provide_context=True,
-        trigger_rule= 'all_done',
+        trigger_rule= 'all_success',
         dag=dag
     )
 


### PR DESCRIPTION
with trigger as `all_done` even after task failure , the job_end_event shall run successfully, marking the job run state as successful, 

setting the trigger to `all_success` we can avoid that situation.