### PR TITLE
feat: call job run input to compile + fetch assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.13
 
 COPY optimus /usr/bin/optimus
 
+# use this part on airflow task to fetch and compile assets by optimus client
 COPY ./entrypoint_init_container.sh /opt/entrypoint_init_container.sh
 RUN chmod +x /opt/entrypoint_init_container.sh
 

--- a/entrypoint_init_container.sh
+++ b/entrypoint_init_container.sh
@@ -18,7 +18,16 @@ echo "OPTIMUS_HOST:$OPTIMUS_HOST"
 echo ""
 
 echo "-- initializing optimus assets"
-OPTIMUS_ADMIN_ENABLED=1 optimus admin build instance "$JOB_NAME" --project-name \
+OPTIMUS_ADMIN_ENABLED=1 optimus job run-input "$JOB_NAME" --project-name \
 	"$PROJECT" --output-dir "$JOB_DIR" \
 	--type "$INSTANCE_TYPE" --name "$INSTANCE_NAME" \
 	--scheduled-at "$SCHEDULED_AT" --host "$OPTIMUS_HOST"
+
+if [ $? -ne 0 ]; then
+echo "-- job run-input failed"
+echo "-- try to register and initializing optimus assets"
+OPTIMUS_ADMIN_ENABLED=1 /opt/optimus admin build instance "$JOB_NAME" --project-name \
+	"$PROJECT" --output-dir "$JOB_DIR" \
+	--type "$INSTANCE_TYPE" --name "$INSTANCE_NAME" \
+	--scheduled-at "$SCHEDULED_AT" --host "$OPTIMUS_HOST"
+fi


### PR DESCRIPTION
Command job run-input will fail if the task instance before `job_start_event` feat introduced is triggered. It happens because the old instance is not registered in the `job_run` table yet. So we need to register the instance either using `admin build instance` or manually trigger `job_start_event`.

In this implementation, fail to run command `job run-input` will fallback to `admin build instance`