### PR TITLE
fix : add non-root user in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG USER=optimus
 COPY optimus /usr/bin/optimus
 WORKDIR /app 
 
-RUN adduser $USER
+RUN adduser -D $USER 
 RUN chown -R $USER:$USER /app
 
 USER $USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM alpine:3.13
+ARG USER=optimus
 
 COPY optimus /usr/bin/optimus
+WORKDIR /app 
 
+RUN adduser $USER
+RUN chown -R $USER:$USER /app
+
+USER $USER
 EXPOSE 8080
 CMD ["optimus"]


### PR DESCRIPTION
The user in Optimus Dockerfile when configured/overridden to be non-root user will cause file permission issue as default user in alpine is root.
In order to support plugin installation on server boot, default non-root user is added to Dockerfile.