### PR TITLE
fix: job bounded context issues

### DIFF
--- a/core/job/job.go
+++ b/core/job/job.go
@@ -144,6 +144,16 @@ func (w WithUpstream) GetUnresolvedUpstreams() []*Upstream {
 	return unresolvedUpstreams
 }
 
+func (w WithUpstream) GetResolvedUpstreams() []*Upstream {
+	var resolvedUpstreams []*Upstream
+	for _, upstream := range w.upstreams {
+		if upstream.state == UpstreamStateResolved {
+			resolvedUpstreams = append(resolvedUpstreams, upstream)
+		}
+	}
+	return resolvedUpstreams
+}
+
 type WithUpstreams []*WithUpstream
 
 func (w WithUpstreams) GetSubjectJobNames() []Name {

--- a/core/job/job_test.go
+++ b/core/job/job_test.go
@@ -114,6 +114,21 @@ func TestEntityJob(t *testing.T) {
 			assert.EqualValues(t, expected, unresolvedUpstreams)
 		})
 	})
+	t.Run("GetResolvedUpstreams", func(t *testing.T) {
+		t.Run("should return upstreams with state resolved", func(t *testing.T) {
+			upstreamUnresolved1 := job.NewUpstreamUnresolvedStatic("job-B", project.Name())
+			upstreamUnresolved2 := job.NewUpstreamUnresolvedInferred("project.dataset.sample-c")
+			upstreamResolved1 := job.NewUpstreamResolved("job-d", "host-sample", "project.dataset.sample-d", sampleTenant, job.UpstreamTypeStatic, "", false)
+			upstreamResolved2 := job.NewUpstreamResolved("job-e", "host-sample", "project.dataset.sample-e", sampleTenant, job.UpstreamTypeInferred, "", true)
+
+			expected := []*job.Upstream{upstreamResolved1, upstreamResolved2}
+
+			jobAWithUpstream := job.NewWithUpstream(jobA, []*job.Upstream{upstreamUnresolved1, upstreamResolved1, upstreamResolved2, upstreamUnresolved2})
+
+			resolvedUpstreams := jobAWithUpstream.GetResolvedUpstreams()
+			assert.EqualValues(t, expected, resolvedUpstreams)
+		})
+	})
 	t.Run("UpstreamTypeFrom", func(t *testing.T) {
 		t.Run("should create static upstream type from string", func(t *testing.T) {
 			upstreamType, err := job.UpstreamTypeFrom("static")

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -250,7 +250,10 @@ func (j JobService) ReplaceAll(ctx context.Context, jobTenant tenant.Tenant, spe
 	me.Append(err)
 
 	tenantWithDetails, err := j.tenantDetailsGetter.GetDetails(ctx, jobTenant)
-	me.Append(err)
+	if err != nil {
+		me.Append(err)
+		return errors.MultiToError(me)
+	}
 
 	addedJobs, err := j.bulkAdd(ctx, tenantWithDetails, toAdd, logWriter)
 	me.Append(err)

--- a/internal/store/postgres/job/adapter.go
+++ b/internal/store/postgres/job/adapter.go
@@ -288,9 +288,27 @@ func toStorageMetadata(metadataSpec *job.Metadata) ([]byte, error) {
 	if metadataSpec == nil {
 		return nil, nil
 	}
-	metadataResource := &MetadataResource{
-		Request: nil,
-		Limit:   nil,
+
+	var metadataResource *MetadataResource
+	if metadataSpec.Resource() != nil {
+		var resourceRequest *MetadataResourceConfig
+		if metadataSpec.Resource().Request() != nil {
+			resourceRequest = &MetadataResourceConfig{
+				CPU:    metadataSpec.Resource().Request().CPU(),
+				Memory: metadataSpec.Resource().Request().Memory(),
+			}
+		}
+		var resourceLimit *MetadataResourceConfig
+		if metadataSpec.Resource().Limit() != nil {
+			resourceLimit = &MetadataResourceConfig{
+				CPU:    metadataSpec.Resource().Limit().CPU(),
+				Memory: metadataSpec.Resource().Limit().Memory(),
+			}
+		}
+		metadataResource = &MetadataResource{
+			Request: resourceRequest,
+			Limit:   resourceLimit,
+		}
 	}
 
 	metadata := Metadata{

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -434,7 +434,7 @@ func specToJob(spec *Spec) (*job.Job, error) {
 
 	destination := job.ResourceURN(spec.Destination)
 
-	sources := []job.ResourceURN{}
+	var sources []job.ResourceURN
 	for _, source := range spec.Sources {
 		resourceURN := job.ResourceURN(source)
 		sources = append(sources, resourceURN)

--- a/internal/store/postgres/job/job_repository_test.go
+++ b/internal/store/postgres/job/job_repository_test.go
@@ -137,6 +137,10 @@ func TestPostgresJobRepository(t *testing.T) {
 			addedJobs, err := jobRepo.Add(ctx, jobs)
 			assert.NoError(t, err)
 			assert.EqualValues(t, jobs, addedJobs)
+
+			storedJobs, err := jobRepo.GetAllByProjectName(ctx, proj.Name())
+			assert.NoError(t, err)
+			assert.EqualValues(t, jobs, storedJobs)
 		})
 		t.Run("inserts job spec with optional fields empty", func(t *testing.T) {
 			db := dbSetup()


### PR DESCRIPTION
- [x] Internal upstream is not being persisted in job_upstream table, due to not included in external upstream resolver.
- [x] Panic when project / namespace is not registered yet
- [x] Inaccurate equality check for job specs 