### PR TITLE
fix: bug in __lib.py

### DIFF
--- a/ext/scheduler/airflow2/resources/__lib.py
+++ b/ext/scheduler/airflow2/resources/__lib.py
@@ -200,7 +200,7 @@ class SuperKubernetesPodOperator(KubernetesPodOperator):
 
             if len(pod_list.items) == 1:
                 try_numbers_match = self._try_numbers_match(context, pod_list.items[0])
-                final_state, result = self.handle_pod_overlap(labels, try_numbers_match, launcher, pod_list.items[0])
+                final_state, _, result = self.handle_pod_overlap(labels, try_numbers_match, launcher, pod_list.items[0])
             else:
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
 


### PR DESCRIPTION
This PR is to address bug in `__lib.py` file. This causes job to fail if execution meet the criteria. The following is the error message if this bug is encountered:

```zsh
ValueError: too many values to unpack (expected 2)
```