### PR TITLE
fix: empty upstream job id issue and dependency resolution on job inspect issue

### DIFF
--- a/core/job/handler/v1beta1/job.go
+++ b/core/job/handler/v1beta1/job.go
@@ -168,7 +168,7 @@ func (jh *JobHandler) GetJobSpecification(ctx context.Context, req *pb.GetJobSpe
 	}
 
 	jobSpec, err := jh.jobService.Get(ctx, jobTenant, jobName)
-	if err != nil {
+	if err != nil && !errors.IsErrorType(err, errors.ErrNotFound) {
 		errorMsg := "failed to get job specification"
 		jh.l.Error(fmt.Sprintf("%s: %s", err.Error(), errorMsg))
 		return nil, errors.GRPCErr(err, errorMsg)

--- a/core/job/handler/v1beta1/job_test.go
+++ b/core/job/handler/v1beta1/job_test.go
@@ -890,7 +890,7 @@ func TestNewJobHandler(t *testing.T) {
 
 			jobService.On("ReplaceAll", ctx, sampleTenant, mock.Anything, []job.Name{"job-A"}, mock.Anything).Return(nil)
 
-			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Twice()
+			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Times(3)
 
 			err := jobHandler.ReplaceAllJobSpecifications(stream)
 			assert.ErrorContains(t, err, "error when replacing job specifications")
@@ -941,7 +941,7 @@ func TestNewJobHandler(t *testing.T) {
 
 			jobService.On("ReplaceAll", ctx, sampleTenant, mock.Anything, jobNamesWithValidationError, mock.Anything).Return(nil)
 
-			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Times(3)
+			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Times(4)
 
 			err := jobHandler.ReplaceAllJobSpecifications(stream)
 			assert.Error(t, err)
@@ -990,7 +990,7 @@ func TestNewJobHandler(t *testing.T) {
 
 			jobService.On("ReplaceAll", ctx, sampleTenant, mock.Anything, jobNamesWithValidationError, mock.Anything).Return(errors.New("internal error"))
 
-			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Twice()
+			stream.On("Send", mock.AnythingOfType("*optimus.ReplaceAllJobSpecificationsResponse")).Return(nil).Times(3)
 
 			err := jobHandler.ReplaceAllJobSpecifications(stream)
 			assert.Error(t, err)

--- a/core/job/service/job_service.go
+++ b/core/job/service/job_service.go
@@ -150,12 +150,10 @@ func (j JobService) Get(ctx context.Context, jobTenant tenant.Tenant, jobName jo
 	if err != nil {
 		return nil, err
 	}
-	if len(jobs) > 0 {
-		return jobs[0], nil
+	if len(jobs) == 0 {
+		return nil, errors.NotFound(job.EntityJob, fmt.Sprintf("job %s is not found", jobName))
 	}
-
-	// TODO: should not return dummy job
-	return &job.Job{}, nil
+	return jobs[0], nil
 }
 
 func (j JobService) GetTaskInfo(ctx context.Context, task job.Task) (*plugin.Info, error) {
@@ -597,10 +595,6 @@ func (j JobService) GetJobBasicInfo(ctx context.Context, jobTenant tenant.Tenant
 		subjectJob, err = j.Get(ctx, jobTenant, jobName)
 		if err != nil {
 			logger.Write(writer.LogLevelError, fmt.Sprintf("unable to get job, err: %v", err))
-			return nil, logger
-		}
-		if subjectJob == nil {
-			logger.Write(writer.LogLevelError, fmt.Sprintf("job %s not found in the server", jobName.String()))
 			return nil, logger
 		}
 	}

--- a/core/job/service/job_service_test.go
+++ b/core/job/service/job_service_test.go
@@ -2156,11 +2156,11 @@ func TestJobService(t *testing.T) {
 
 			specA, _ := job.NewSpecBuilder(jobVersion, "job-A", "sample-owner", jobSchedule, jobWindow, jobTask).Build()
 
-			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(nil, nil)
+			jobRepo.On("GetByJobName", ctx, project.Name(), specA.Name()).Return(nil, errors.New("job not found"))
 
 			jobService := service.NewJobService(jobRepo, pluginService, upstreamResolver, tenantDetailsGetter, log)
 			result, logger := jobService.GetJobBasicInfo(ctx, sampleTenant, specA.Name(), nil)
-			assert.Contains(t, logger.Messages[0].Message, "job job-A not found in the server")
+			assert.Contains(t, logger.Messages[0].Message, "job not found")
 			assert.Nil(t, result)
 		})
 		t.Run("should write log if found existing job with same resource destination", func(t *testing.T) {

--- a/internal/store/postgres/job/adapter.go
+++ b/internal/store/postgres/job/adapter.go
@@ -253,14 +253,6 @@ func toStorageSchedule(scheduleSpec *job.Schedule) ([]byte, error) {
 		return nil, err
 	}
 
-	var endDate time.Time
-	if scheduleSpec.EndDate() != "" {
-		endDate, err = time.Parse(jobDatetimeLayout, scheduleSpec.EndDate().String())
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var retry *Retry
 	if scheduleSpec.Retry() != nil {
 		retry = &Retry{
@@ -272,11 +264,17 @@ func toStorageSchedule(scheduleSpec *job.Schedule) ([]byte, error) {
 
 	schedule := Schedule{
 		StartDate:     startDate,
-		EndDate:       &endDate,
 		Interval:      scheduleSpec.Interval(),
 		DependsOnPast: scheduleSpec.DependsOnPast(),
 		CatchUp:       scheduleSpec.CatchUp(),
 		Retry:         retry,
+	}
+	if scheduleSpec.EndDate() != "" {
+		endDate, err := time.Parse(jobDatetimeLayout, scheduleSpec.EndDate().String())
+		if err != nil {
+			return nil, err
+		}
+		schedule.EndDate = &endDate
 	}
 	return json.Marshal(schedule)
 }
@@ -468,7 +466,7 @@ func fromStorageSchedule(raw []byte) (*job.Schedule, error) {
 		WithDependsOnPast(storageSchedule.DependsOnPast).
 		WithInterval(storageSchedule.Interval)
 
-	if !storageSchedule.EndDate.IsZero() {
+	if storageSchedule.EndDate != nil && !storageSchedule.EndDate.IsZero() {
 		endDate, err := job.ScheduleDateFrom(storageSchedule.EndDate.Format(job.DateLayout))
 		if err != nil {
 			return nil, err

--- a/internal/store/postgres/job/adapter.go
+++ b/internal/store/postgres/job/adapter.go
@@ -54,7 +54,7 @@ type Spec struct {
 
 type Schedule struct {
 	StartDate     time.Time
-	EndDate       *time.Time
+	EndDate       *time.Time `json:",omitempty"`
 	Interval      string
 	DependsOnPast bool
 	CatchUp       bool

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -170,7 +170,11 @@ func (j JobRepository) get(ctx context.Context, projectName tenant.ProjectName, 
 		getJobByNameAtProject += jobDeletedFilter
 	}
 
-	return FromRow(j.db.QueryRow(ctx, getJobByNameAtProject, jobName.String(), projectName.String()))
+	spec, err := FromRow(j.db.QueryRow(ctx, getJobByNameAtProject, jobName.String(), projectName.String()))
+	if errors.IsErrorType(err, errors.ErrNotFound) {
+		err = errors.NotFound(job.EntityJob, fmt.Sprintf("unable to get job %s", jobName))
+	}
+	return spec, err
 }
 
 func (j JobRepository) ResolveUpstreams(ctx context.Context, projectName tenant.ProjectName, jobNames []job.Name) (map[job.Name][]*job.Upstream, error) {

--- a/internal/store/postgres/job/job_repository.go
+++ b/internal/store/postgres/job/job_repository.go
@@ -516,7 +516,7 @@ INSERT INTO job_upstream (
 )
 VALUES (
 	(select id FROM job WHERE name = $1 and project_name = $2), $1, $2,
-	(select id FROM job WHERE name = $3 and project_name = $4), $3, $4,
+	(select id FROM job WHERE name = $3 and project_name = $5), $3, $4,
 	$5, $6, $7,
 	$8, $9,
 	$10, $11,

--- a/internal/store/postgres/scheduler/job_repository.go
+++ b/internal/store/postgres/scheduler/job_repository.go
@@ -198,7 +198,7 @@ func (j *Job) toJobWithDetails() (*scheduler.JobWithDetails, error) {
 			Interval:      storageSchedule.Interval,
 		},
 	}
-	if !storageSchedule.EndDate.IsZero() {
+	if !(storageSchedule.EndDate == nil || storageSchedule.EndDate.IsZero()) {
 		schedulerJobWithDetails.Schedule.EndDate = storageSchedule.EndDate
 	}
 


### PR DESCRIPTION
1. `upstream_job_id` in `job_upstream` table is always empty, causing any deletion in `job` table will not automatically deleting the entries in `job_upstream` table.
2. failure when resolving static dependency when **inspecting** a non-existing job which does not have static upstream specified.
3. summarize replace all error messages (all namespaces) in the end of the process.
4. failure when job is not found when inspecting.
5. unclear upstream job not found log when inspecting.