### PR TITLE
fix: avoid unnecessary upstream resolver process and improve server logs

### DIFF
--- a/core/job/resolver/external_upstream_resolver.go
+++ b/core/job/resolver/external_upstream_resolver.go
@@ -66,6 +66,10 @@ func (e *extUpstreamResolver) Resolve(ctx context.Context, jobWithUpstream *job.
 }
 
 func (e *extUpstreamResolver) BulkResolve(ctx context.Context, jobsWithUpstream []*job.WithUpstream, lw writer.LogWriter) ([]*job.WithUpstream, error) {
+	if len(e.optimusResourceManagers) == 0 {
+		return jobsWithUpstream, nil
+	}
+
 	me := errors.NewMultiError("external upstream resolution errors")
 
 	var jobsWithAllUpstream []*job.WithUpstream

--- a/core/job/resolver/external_upstream_resolver_test.go
+++ b/core/job/resolver/external_upstream_resolver_test.go
@@ -34,7 +34,7 @@ func TestExternalUpstreamResolver(t *testing.T) {
 	specA, _ := job.NewSpecBuilder(jobVersion, "job-A", "sample-owner", jobSchedule, jobWindow, jobTask).WithSpecUpstream(upstreamSpec).Build()
 	jobA := job.NewJob(sampleTenant, specA, "", []job.ResourceURN{"resource-C"})
 
-	t.Run("Resolve", func(t *testing.T) {
+	t.Run("BulkResolve", func(t *testing.T) {
 		t.Run("resolves upstream externally", func(t *testing.T) {
 			logWriter := new(mockWriter)
 			defer logWriter.AssertExpectations(t)
@@ -95,6 +95,19 @@ func TestExternalUpstreamResolver(t *testing.T) {
 			result, err := extUpstreamResolver.BulkResolve(ctx, []*job.WithUpstream{jobWithUnresolvedUpstream}, logWriter)
 			assert.EqualValues(t, []*job.Upstream{unresolvedUpstreamB, unresolvedUpstreamC}, result[0].Upstreams())
 			assert.NotNil(t, err)
+		})
+		t.Run("skips resolves upstream externally if no external resource manager found", func(t *testing.T) {
+			logWriter := new(mockWriter)
+			defer logWriter.AssertExpectations(t)
+
+			unresolvedUpstreamB := job.NewUpstreamUnresolvedStatic("job-B", externalTenant.ProjectName())
+			unresolvedUpstreamC := job.NewUpstreamUnresolvedInferred("resource-C")
+			jobWithUnresolvedUpstream := job.NewWithUpstream(jobA, []*job.Upstream{unresolvedUpstreamB, unresolvedUpstreamC})
+
+			extUpstreamResolver := resolver.NewTestExternalUpstreamResolver(nil)
+			result, err := extUpstreamResolver.BulkResolve(ctx, []*job.WithUpstream{jobWithUnresolvedUpstream}, logWriter)
+			assert.Nil(t, err)
+			assert.EqualValues(t, jobWithUnresolvedUpstream, result[0])
 		})
 	})
 	t.Run("NewExternalUpstreamResolver", func(t *testing.T) {


### PR DESCRIPTION
- Skip the external upstream resolver (bulk) process when external resource manager is not found.
- Add more server logs on job bounded context
- Add replace all, refresh, and validation duration metrics