### PR TITLE
fix: override depends_on_past's dag level value

### DIFF
--- a/ext/scheduler/airflow2/resources/base_dag.py
+++ b/ext/scheduler/airflow2/resources/base_dag.py
@@ -42,7 +42,7 @@ default_args = {
     "queue": "{{ .Metadata.Airflow.Queue }}",
     {{- end }}
     "owner": {{.Job.Owner | quote}},
-    "depends_on_past": False,
+    "depends_on_past": {{ if .Job.Behavior.DependsOnPast }}True{{- else -}}False{{- end -}},
     "retries": {{ if gt .Job.Behavior.Retry.Count 0 -}} {{.Job.Behavior.Retry.Count}} {{- else -}} DAG_RETRIES {{- end}},
     "retry_delay": {{ if gt .Job.Behavior.Retry.Delay.Nanoseconds 0 -}} timedelta(seconds={{.Job.Behavior.Retry.Delay.Seconds}}) {{- else -}} timedelta(seconds=DAG_RETRY_DELAY) {{- end}},
     "retry_exponential_backoff": {{if .Job.Behavior.Retry.ExponentialBackoff -}}True{{- else -}}False{{- end -}},

--- a/ext/scheduler/airflow2/resources/expected_compiled_template.py
+++ b/ext/scheduler/airflow2/resources/expected_compiled_template.py
@@ -36,7 +36,7 @@ default_args = {
         "optimus_hostname": "http://airflow.example.io"
     },
     "owner": "mee@mee",
-    "depends_on_past": False,
+    "depends_on_past": True,
     "retries": 4,
     "retry_delay": timedelta(seconds=DAG_RETRY_DELAY),
     "retry_exponential_backoff": True,


### PR DESCRIPTION
`depends_on_past` value in job level configuration (not task), should also be overrideable from the user's configuration to avoid having a dag in a deadlock state (when scheduler schedules run in a random run order).